### PR TITLE
changing name of test suit in order to remove conflict

### DIFF
--- a/main/appserver/tests/quicklook/wsit/JaxwsFromWsdl/testng.xml
+++ b/main/appserver/tests/quicklook/wsit/JaxwsFromWsdl/testng.xml
@@ -2,7 +2,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/main/appserver/tests/quicklook/wsit/JaxwsFromWsdl/testng.xml
+++ b/main/appserver/tests/quicklook/wsit/JaxwsFromWsdl/testng.xml
@@ -43,7 +43,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
  
 <suite name="QuickLookTests" verbose="2" >
-  <test name="wsit_jaxws_tests">
+  <test name="wsit_jaxws_wsdl_tests">
     <classes>
       <class name="jaxwsfromwsdl.client.JaxwsFromWsdlTestNG"/>
     </classes>


### PR DESCRIPTION
changing name of test as  junit file was getting overridden (after workaround fix) and it was showing only 117 tests in hudson job.

