### PR TITLE
Fix for #21702 - Update Java EE version in master pom.xml to EE8

### DIFF
--- a/main/appserver/pom.xml
+++ b/main/appserver/pom.xml
@@ -94,7 +94,7 @@
         <update_version></update_version>
         <install.dir.name>glassfish5</install.dir.name>
 
-        <javaee.major_version>7</javaee.major_version>
+        <javaee.major_version>8</javaee.major_version>
         <javaee.version_qualifier>-b${build.id}</javaee.version_qualifier>
         <javaee.version>${javaee.major_version}.${minor_version}${javaee.version_qualifier}</javaee.version>
 


### PR DESCRIPTION
Fixes #21702  - Update Java EE version in master pom.xml to EE8 