### PR TITLE
Upgrade JavaMail to 1.6.0-rc2 - fixes #21790

### DIFF
--- a/main/nucleus/pom.xml
+++ b/main/nucleus/pom.xml
@@ -183,7 +183,7 @@
         <logging-annotation-processor.version>1.7</logging-annotation-processor.version>
         <command-security-plugin.version>1.0.7</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
-        <mail.version>1.6.0-rc1</mail.version>
+        <mail.version>1.6.0-rc2</mail.version>
         <javax.annotation-api.version>1.3-b01</javax.annotation-api.version>
         <copyright-plugin.version>1.42</copyright-plugin.version>
         <jdk.version>1.7.0-09</jdk.version>


### PR DESCRIPTION
Builds locally and passes quicklook locally.