### PR TITLE
Fix for #21815 : Incorrect URL for openDS download in security devtest

### DIFF
--- a/main/appserver/tests/appserv-tests/devtests/security/run_test.sh
+++ b/main/appserver/tests/appserv-tests/devtests/security/run_test.sh
@@ -51,6 +51,8 @@ test_run(){
 
 	# Workaround for JDK7 and OpenDS
 	cp $APS_HOME/devtests/security/ldap/opends/X500Signer.jar $OPENDS_HOME/lib
+	rm -rf $OPENDS_HOME/lib/set-java-home
+	export OPENDS_JAVA_HOME=/gf-hudson-tools/jdk/7/latest
 
 	# Configure and start OpenDS using the default ports
 	$OPENDS_HOME/setup -i -v -n -p 1389 --adminConnectorPort 4444 -x 1689 -w dmanager -b "dc=sfbay,dc=sun,dc=com" -Z 1636 --useJavaKeystore $S1AS_HOME/domains/domain1/config/keystore.jks -W changeit -N s1as

--- a/main/appserver/tests/appserv-tests/devtests/security/run_test.sh
+++ b/main/appserver/tests/appserv-tests/devtests/security/run_test.sh
@@ -43,9 +43,8 @@ test_run(){
 	rm -rf opends-image
 	mkdir opends-image
 	pushd opends-image
-
-	wget --no-check-certificate http://java.net/downloads/opends/promoted-builds/2.2.1/OpenDS-2.2.1.zip
-	unzip -q OpenDS-2.2.1.zip
+	
+	unzip -q /net/gf-hudson/scratch/java_re_node/OpenDS-2.2.1.zip
 
 	export OPENDS_HOME=$PWD/OpenDS-2.2.1
 	popd


### PR DESCRIPTION
Fixes #21815 : The OpenDS-2.2.1.zip download location has been changed.