### PR TITLE
Fixes #21823: Modifying security devtests to remove deprecated cipher tests.

### DIFF
--- a/main/appserver/tests/appserv-tests/devtests/security/ciphertest/build.xml
+++ b/main/appserver/tests/appserv-tests/devtests/security/ciphertest/build.xml
@@ -149,19 +149,7 @@
 
       <property name="https.1.port" value="1${https.port}" />
       <property name="https.2.port" value="2${https.port}" />
-      <!-- Skip below https://jira.oraclecorp.com/jira/browse/IDCINTER-82
-      <antcall target="cipher-test">
-        <param name="should-pass-cipher" value="SSL_RSA_WITH_RC4_128_MD5"/>
-        <param name="enable-cipher"      value="SSL_RSA_WITH_RC4_128_MD5"/>
-        <param name="https.port"         value="${https.1.port}"/>
-      </antcall>
-     
-      <antcall target="cipher-test">
-        <param name="should-pass-cipher" value=""/>
-        <param name="enable-cipher"      value="SSL_RSA_WITH_3DES_EDE_CBC_SHA"/>
-        <param name="https.port"         value="${https.1.port}"/>
-      </antcall>-->
-
+      
       <antcall target="cipher-test">
         <param name="should-pass-cipher" value=""/>
         <param name="enable-cipher"      value="SSL_RSA_WITH_DES_CBC_SHA"/>
@@ -224,13 +212,7 @@
         <param name="enable-cipher"      value="SSL_RSA_WITH_NULL_MD5"/>
         <param name="https.port"         value="${https.2.port}"/>
       </antcall>
-      <!-- Skip below https://jira.oraclecorp.com/jira/browse/IDCINTER-82
-      <antcall target="cipher-test">
-        <param name="should-pass-cipher" value="SSL_RSA_WITH_RC4_128_SHA"/>
-        <param name="enable-cipher"      value="SSL_RSA_WITH_RC4_128_SHA"/>
-        <param name="https.port"         value="${https.2.port}"/>
-      </antcall>-->
-
+      
       <antcall target="cipher-test">
         <param name="should-pass-cipher" value="SSL_RSA_WITH_NULL_SHA"/>
         <param name="enable-cipher"      value="SSL_RSA_WITH_NULL_SHA"/>

--- a/main/appserver/tests/appserv-tests/devtests/security/resultCount.sh
+++ b/main/appserver/tests/appserv-tests/devtests/security/resultCount.sh
@@ -43,7 +43,7 @@
 
 FILES="$APS_HOME/test_resultsValid.xml $APS_HOME/security-gtest-results.xml"
 
-TOTAL=741
+TOTAL=738
 PASSED=0
 FAILED=0
 for i in $FILES


### PR DESCRIPTION
Fixes #21823 : There are three cipher tests that are not valid for jdk8. Hence can be removed from security devtests.