### PR TITLE
Fixes #21819 : Updated maven-bundle-plugin version to 2.4.0

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.4.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.4</version>
+                    <version>2.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #21819 : The suggested fix is to update the maven-bundle-plugin version to 2.4.0 to avoid bundle build issues