### PR TITLE
Fixes 21877 : devtest to validate inbuilt identity store behavior.

### DIFF
--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+    <parent>
+        <groupId>org.glassfish.soteria.test</groupId>
+        <artifactId>soteria</artifactId>
+        <version>5.0-SNAPSHOT</version>
+    </parent>
+	
+	<artifactId>app-db</artifactId>
+	<packaging>war</packaging>
+	
+	<build>
+        <finalName>app-db</finalName>
+	</build>
+    
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.soteria.test</groupId>
+            <artifactId>common</artifactId>
+            <version>5.0-SNAPSHOT</version>
+            <scope>test</scope> 
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
@@ -1,0 +1,102 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.soteria.test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.sql.DataSource;
+
+@Singleton
+@Startup
+public class DatabaseSetup {
+    
+    @Resource(lookup="java:comp/DefaultDataSource")	
+    private DataSource dataSource;
+
+    @PostConstruct
+    public void init() {
+        
+        executeUpdate(dataSource, "CREATE TABLE caller(name VARCHAR(64) PRIMARY KEY, password VARCHAR(64))");
+        executeUpdate(dataSource, "CREATE TABLE caller_groups(caller_name VARCHAR(64), group_name VARCHAR(64))");
+        
+        executeUpdate(dataSource, "INSERT INTO caller VALUES('reza', 'secret1')");
+        executeUpdate(dataSource, "INSERT INTO caller VALUES('alex', 'secret2')");
+        executeUpdate(dataSource, "INSERT INTO caller VALUES('arjan', 'secret2')");
+        executeUpdate(dataSource, "INSERT INTO caller VALUES('werner', 'secret2')");
+        
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('reza', 'foo')");
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('reza', 'bar')");
+        
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('alex', 'foo')");
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('alex', 'bar')");
+        
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('arjan', 'foo')");
+        executeUpdate(dataSource, "INSERT INTO caller_groups VALUES('werner', 'foo')");
+    }
+    
+    @PreDestroy
+    public void destroy() {
+    	try {
+    		executeUpdate(dataSource, "DROP TABLE caller");
+    		executeUpdate(dataSource, "DROP TABLE caller_groups");
+    	} catch (Exception e) {
+    		// silently ignore, concerns in-memory database
+    	}
+    }
+    
+    private void executeUpdate(DataSource dataSource, String query) {
+        try (Connection connection = dataSource.getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.executeUpdate();
+            }
+        } catch (SQLException e) {
+           throw new IllegalStateException(e);
+        }
+    }
+    
+}

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,0 +1,86 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.soteria.test;
+
+import java.io.IOException;
+
+import javax.annotation.security.DeclareRoles;
+import javax.security.enterprise.identitystore.DataBaseIdentityStoreDefinition;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Test Servlet that prints out the name of the authenticated caller and whether
+ * this caller is in any of the roles {foo, bar, kaz}
+ * 
+ *
+ */
+@DataBaseIdentityStoreDefinition(
+    dataSourceLookup="jdbc/__default", 
+    callerQuery="select password from caller where name = ?",
+    groupsQuery="select group_name from caller_groups where caller_name = ?"
+)
+@DeclareRoles({ "foo", "bar", "kaz" })
+@WebServlet("/servlet")
+public class Servlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a servlet \n");
+
+        String webName = null;
+        if (request.getUserPrincipal() != null) {
+            webName = request.getUserPrincipal().getName();
+        }
+
+        response.getWriter().write("web username: " + webName + "\n");
+
+        response.getWriter().write("web user has role \"foo\": " + request.isUserInRole("foo") + "\n");
+        response.getWriter().write("web user has role \"bar\": " + request.isUserInRole("bar") + "\n");
+        response.getWriter().write("web user has role \"kaz\": " + request.isUserInRole("kaz") + "\n");
+    }
+
+}

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,0 +1,96 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.soteria.test;
+
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.security.auth.message.AuthException;
+import javax.security.enterprise.AuthenticationStatus;
+import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import javax.security.enterprise.credential.Password;
+import javax.security.enterprise.credential.UsernamePasswordCredential;
+import javax.security.enterprise.identitystore.CredentialValidationResult;
+import javax.security.enterprise.identitystore.IdentityStoreHandler;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+
+@RequestScoped
+public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
+    
+    @Inject
+    private IdentityStoreHandler identityStoreHandler;
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthException {
+
+        if (request.getParameter("name") != null && request.getParameter("password") != null) {
+
+            // Get the (caller) name and password from the request
+            // NOTE: This is for the smallest possible example only. In practice
+            // putting the password in a request query parameter is highly
+            // insecure
+            String name = request.getParameter("name");
+            Password password = new Password(request.getParameter("password"));
+
+            // Delegate the {credentials in -> identity data out} function to
+            // the Identity Store
+            CredentialValidationResult result = identityStoreHandler.validate(
+                new UsernamePasswordCredential(name, password));
+
+            if (result.getStatus() == VALID) {
+                // Communicate the details of the authenticated user to the
+                // container. In many cases the underlying handler will just store the details 
+                // and the container will actually handle the login after we return from 
+                // this method.
+                return httpMessageContext.notifyContainerAboutLogin(
+                    result.getCallerPrincipal(), result.getCallerGroups());
+            } else {
+                return httpMessageContext.responseUnAuthorized();
+            }
+        } 
+
+        return httpMessageContext.doNothing();
+    }
+    
+}

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+   Copyright (c) 2015, 2016 Oracle and/or its affiliates. All rights reserved.
+
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   http://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+   or packager/legal/LICENSE.txt.  See the License for the specific
+   language governing permissions and limitations under the License.
+
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at packager/legal/LICENSE.txt.
+
+   GPL Classpath Exception:
+   Oracle designates this particular file as subject to the "Classpath"
+   exception as provided by Oracle in the GPL Version 2 section of the License
+   file that accompanied this code.
+
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+
+-->
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+
+    <security-role-mapping>
+        <role-name>foo</role-name>
+        <group-name>foo</group-name>
+    </security-role-mapping>
+    
+    <security-role-mapping>
+        <role-name>bar</role-name>
+        <group-name>bar</group-name>
+    </security-role-mapping>
+    
+    <security-role-mapping>
+        <role-name>kaz</role-name>
+        <group-name>kaz</group-name>
+    </security-role-mapping>
+
+    <parameter-encoding default-charset="UTF-8" />
+
+</glassfish-web-app>

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -3,34 +3,34 @@
 
        DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) 2015, 2016 Oracle and/or its affiliates. All rights reserved.
+       Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 
-   The contents of this file are subject to the terms of either the GNU
-   General Public License Version 2 only ("GPL") or the Common Development
-   and Distribution License("CDDL") (collectively, the "License").  You
-   may not use this file except in compliance with the License.  You can
-   obtain a copy of the License at
-   http://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-   or packager/legal/LICENSE.txt.  See the License for the specific
-   language governing permissions and limitations under the License.
+       The contents of this file are subject to the terms of either the GNU
+       General Public License Version 2 only ("GPL") or the Common Development
+       and Distribution License("CDDL") (collectively, the "License").  You
+       may not use this file except in compliance with the License.  You can
+       obtain a copy of the License at
+       https://oss.oracle.com/licenses/CDDL+GPL-1.1
+       or LICENSE.txt.  See the License for the specific
+       language governing permissions and limitations under the License.
 
-   When distributing the software, include this License Header Notice in each
-   file and include the License file at packager/legal/LICENSE.txt.
+       When distributing the software, include this License Header Notice in each
+       file and include the License file at LICENSE.txt.
 
-   GPL Classpath Exception:
-   Oracle designates this particular file as subject to the "Classpath"
-   exception as provided by Oracle in the GPL Version 2 section of the License
-   file that accompanied this code.
+       GPL Classpath Exception:
+       Oracle designates this particular file as subject to the "Classpath"
+       exception as provided by Oracle in the GPL Version 2 section of the License
+       file that accompanied this code.
 
-   Modifications:
-   If applicable, add the following below the License Header, with the fields
-   enclosed by brackets [] replaced by your own identifying information:
-   "Portions Copyright [year] [name of copyright owner]"
+       Modifications:
+       If applicable, add the following below the License Header, with the fields
+       enclosed by brackets [] replaced by your own identifying information:
+       "Portions Copyright [year] [name of copyright owner]"
 
-   Contributor(s):
-   If you wish your version of this file to be governed by only the CDDL or
-   only the GPL Version 2, indicate your decision by adding "[Contributor]
-   elects to include this software in this distribution under the [CDDL or GPL
+       Contributor(s):
+       If you wish your version of this file to be governed by only the CDDL or
+       only the GPL Version 2, indicate your decision by adding "[Contributor]
+       elects to include this software in this distribution under the [CDDL or GPL
    Version 2] license."  If you don't indicate a single choice of license, a
    recipient has the option to distribute your version of this file under
    either the CDDL, the GPL Version 2 or to extend the choice of license to

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
@@ -65,11 +65,12 @@ public class AppDBIT extends ArquillianBase {
     private static SimpleReporterAdapter stat =
             new SimpleReporterAdapter("appserv-tests");
     @Rule
-    public TestWatcher reportWatcher=new ReportWatcher(stat, "Security::soteria::AppSecurityContextEJB");
+    public TestWatcher reportWatcher=new ReportWatcher(stat, "Security::soteria::AppDBIT");
 
     @AfterClass
     public static void printSummary(){
         stat.printSummary();
+    }
     
 
     @Deployment(testable = false)

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
@@ -54,10 +54,22 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import com.sun.ejte.ccl.reporter.SimpleReporterAdapter;
+import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.rules.TestWatcher;
 
 
 @RunWith(Arquillian.class)
 public class AppDBIT extends ArquillianBase {
+    private static SimpleReporterAdapter stat =
+            new SimpleReporterAdapter("appserv-tests");
+    @Rule
+    public TestWatcher reportWatcher=new ReportWatcher(stat, "Security::soteria::AppSecurityContextEJB");
+
+    @AfterClass
+    public static void printSummary(){
+        stat.printSummary();
     
 
     @Deployment(testable = false)

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
@@ -1,0 +1,92 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.soteria.test;
+
+import static java.lang.System.getProperty;
+import static org.glassfish.soteria.test.Assert.assertDefaultAuthenticated;
+import static org.glassfish.soteria.test.Assert.assertDefaultNotAuthenticated;
+import static org.glassfish.soteria.test.ShrinkWrap.mavenWar;
+import static org.junit.Assume.assumeFalse;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class AppDBIT extends ArquillianBase {
+    
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return mavenWar();
+    }
+
+    @Test
+    public void testAuthenticated() {
+        assertDefaultAuthenticated(
+            readFromServer("/servlet?name=reza&password=secret1"));
+    }
+    
+    @Test
+    public void testNotAuthenticated() {
+        assertDefaultNotAuthenticated(
+            readFromServer("/servlet"));
+    }
+    
+    @Test
+    public void testNotAuthenticatedWrongName() {
+        assertDefaultNotAuthenticated(
+            readFromServer("/servlet?name=romo&password=secret1"));
+    }
+    
+    @Test
+    public void testNotAuthenticatedWrongPassword() {
+        assertDefaultNotAuthenticated(
+            readFromServer("/servlet?name=reza&password=wrongpassword"));
+    }
+
+}

--- a/appserver/tests/appserv-tests/devtests/security/soteria/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/pom.xml
@@ -69,6 +69,7 @@
         <module>app-securitycontext-auth</module>
         <module>app-double-ham</module>
         <module>app-ham-ordering</module>
+	    <module>app-db</module>
         <!-- default role-mapping test is disable till the feature is available
         <module>app-no-role-mapping</module>-->
         


### PR DESCRIPTION
Fixes #21877 

Added devtest to validate inbuilt db id store behavior as per JSR 375 spec.
This test case appears in Soteria repo and has been modified to fit in gf
context.

It uses embedded derby db in glassfish to use as identity store.