### PR TITLE
Fixes #21887 : Added permission check for Security Manager before setting Global context

### DIFF
--- a/appserver/web/web-naming/src/main/java/org/apache/naming/factory/ResourceLinkFactory.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/factory/ResourceLinkFactory.java
@@ -104,6 +104,11 @@ public class ResourceLinkFactory
     public static void setGlobalContext(Context newGlobalContext) {
         if (globalContext != null)
             return;
+        SecurityManager securityManager = System.getSecurityManager();
+        if (securityManager != null) {
+            securityManager.checkPermission(new RuntimePermission(
+                    ResourceLinkFactory.class.getName() + ".setGlobalContext"));
+        }
         globalContext = newGlobalContext;
     }
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>2.3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.4</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #21887 : The suggested fix will add permission check in Security manager before setting Global context.