### PR TITLE
Fixes #21897: Update commons-fileupload version to 1.3.2

### DIFF
--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -61,6 +61,6 @@
 	<parameter-encoding default-charset="UTF-8" />
  </locale-charset-info>
 
-<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.10.jar:WEB-INF/extra/commons-fileupload-1.1.1.jar:WEB-INF/extra/commons-io-1.3.1.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" /> 
+<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.10.jar:WEB-INF/extra/commons-fileupload-1.3.2.jar:WEB-INF/extra/commons-io-1.3.1.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
 
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -799,7 +799,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.1.1</version>
+                <version>1.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.messaging.mq</groupId>

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/MultipartStream.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/MultipartStream.java
@@ -340,10 +340,9 @@ public class MultipartStream {
             byte[] boundary,
             int bufSize,
             ProgressNotifier pNotifier) {
-        this.input = input;
-        this.bufSize = bufSize;
-        this.buffer = new byte[bufSize];
-        this.notifier = pNotifier;
+        if (boundary == null) {
+            throw new IllegalArgumentException("boundary is null");
+        }
 
         // We prepend CR/LF to the boundary to chop trailng CR/LF from
         // body-data tokens.
@@ -352,6 +351,12 @@ public class MultipartStream {
             throw new IllegalArgumentException(
                     "The buffer size specified for the MultipartStream is too small");
         }
+
+        this.input = input;
+        this.bufSize = bufSize;
+        this.buffer = new byte[bufSize];
+        this.notifier = pNotifier;
+
         this.boundary = new byte[this.boundaryLength];
         this.keepRegion = this.boundary.length;
         System.arraycopy(BOUNDARY_PREFIX, 0, this.boundary, 0,

--- a/appserver/web/web-core/src/test/java/org/apache/catalina/fileupload/MultipartStreamTest.java
+++ b/appserver/web/web-core/src/test/java/org/apache/catalina/fileupload/MultipartStreamTest.java
@@ -1,0 +1,140 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ *
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.fileupload;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+
+/**
+ * Unit tests {@link org.apache.commons.fileupload.MultipartStream}.
+ * 
+ * @version $Id$
+ */
+public class MultipartStreamTest {
+    
+    static private final String BOUNDARY_TEXT = "myboundary";
+    
+    /**
+     * The Carriage Return ASCII character value.
+     */
+    public static final byte CR = 0x0D;
+
+
+    /**
+     * The Line Feed ASCII character value.
+     */
+    public static final byte LF = 0x0A;
+
+
+    /**
+     * The dash (-) ASCII character value.
+     */
+    public static final byte DASH = 0x2D;
+    
+    @Test
+    public void testThreeParamConstructor() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        byte[] BOUNDARY_PREFIX = {CR, LF, DASH, DASH};
+        int iBufSize =
+                boundary.length + BOUNDARY_PREFIX.length + 1;
+        MultipartStream ms = new MultipartStream(
+                input,
+                boundary,
+                iBufSize,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+        assertNotNull(ms);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSmallBuffer() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        int iBufSize = 1;
+        @SuppressWarnings("unused")
+        MultipartStream ms = new MultipartStream(
+                input,
+                boundary,
+                iBufSize,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+    }
+
+    @Test
+    public void testTwoParamConstructor() throws Exception {
+        final String strData = "foobar";
+        final byte[] contents = strData.getBytes();
+        InputStream input = new ByteArrayInputStream(contents);
+        byte[] boundary = BOUNDARY_TEXT.getBytes();
+        MultipartStream ms = new MultipartStream(
+                input,
+                boundary,
+                new MultipartStream.ProgressNotifier(null, contents.length));
+        assertNotNull(ms);
+    }
+    
+}

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>2.3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -237,7 +237,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.4</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #21897 : The suggested fix is to update the commons-fileupload version to 1.3.2 