### PR TITLE
Fix for #21682 - Connection Pool bug occurs when Connection Validation is enabled and 'On Any Failure Close All Connections' option is used

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -725,7 +725,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
                     boolean isValid = isConnectionValid(h, alloc);
                     if (h.hasConnectionErrorOccurred() || !isValid) {
                         if (failAllConnections) {
-                            createSingleResourceAndAdjustPool(alloc, spec);
+                            result = createSingleResourceAndAdjustPool(alloc, spec);
                             //no need to match since the resource is created with the allocator of caller.
                             break;
                         } else {
@@ -879,10 +879,6 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
         }
 
         ResourceHandle result = getNewResource(alloc);
-        if (result != null) {
-            alloc.fillInResourceObjects(result);
-            result.getResourceState().setBusy(true);
-        }
 
         return result;
     }
@@ -1246,7 +1242,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener,
     }
 
     private ResourceHandle getNewResource(ResourceAllocator alloc) throws PoolingException {
-        ds.addResource(alloc, 1);
+        addResource(alloc);
         return ds.getResource();
     }
 


### PR DESCRIPTION
Fix for #21682 - Connection Pool bug occurs when Connection Validation is enabled and 'On Any Failure Close All Connections' option is used