### PR TITLE
Fixes #21894 Remove redundant bean-validation implementations from GlassFish

### DIFF
--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -108,10 +108,6 @@
     	    <artifactId>bean-validator-cdi</artifactId>
 	    <version>${bean.validator.cdi.version}</version>
     	</dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator-cdi</artifactId>
-        </dependency>
 	<dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>

--- a/nucleus/packager/external/bean-validator-cdi/pom.xml
+++ b/nucleus/packager/external/bean-validator-cdi/pom.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.glassfish.main.external</groupId>
+        <artifactId>nucleus-external</artifactId>
+        <version>5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>bean-validator-cdi</artifactId>
+    <name>HV. CDI portable extension as OSGi bundle</name>
+    <description>Validation API (JSR 349) version ${javax.validation.version}, Hibernate Validator CDI portable extension version ${hibernate-validator.version} and its dependencies repackaged as OSGi bundle</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>
+                            <!-- Only specify root artifacts that need to be embedded, everything else
+                                 will be pulled in automatically based on Private-Package settings. -->
+                            *; artifactId=hibernate-validator-cdi; inline=true
+                        </Embed-Dependency>
+                        <Export-Package>
+                            org.hibernate.validator.internal.cdi; version=${hibernate-validator.version},
+			    org.hibernate.validator.internal.cdi.interceptor; version=${hibernate-validator.version},
+                        </Export-Package>
+
+                        <Import-Package>
+                            javax.enterprise.inject,
+                            javax.enterprise.inject.*,
+                            *
+                        </Import-Package>
+                        <Implementation-Version>
+                            ${hibernate-validator.version}
+                        </Implementation-Version>
+                    </instructions>
+                    <!-- Maven uses the output directory (target/classes)
+                    rather than the final bundle, when compiling against
+                    projects in the same reactor (ie. the same build).
+                    Since this jar comprises of classes that come from
+                    some other jar and other modules depend on this
+                    artifact, we need to unpack.
+                    -->
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/alternateLocation</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <!--<execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/hibernate-validator-cdi-javadoc.jar</file>
+                                    <classifier>javadoc</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>-->                      
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-sources</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/alternateLocation</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-validator</artifactId>
+                                    <version>${hibernate-validator.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--<execution>
+                        <id>get-javadoc</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-validator-cdi</artifactId>
+                                    <version>${hibernate-validator.version}</version>
+                                    <classifier>javadoc</classifier>
+                                    <overWrite>false</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>-->
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator-cdi</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/nucleus/packager/external/bean-validator/pom.xml
+++ b/nucleus/packager/external/bean-validator/pom.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.glassfish.main.external</groupId>
+        <artifactId>nucleus-external</artifactId>
+        <version>5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>bean-validator</artifactId>
+    <name>javax.validation:${javax.validation.version} as OSGi bundle</name>
+    <description>JSR 349's RI, Hibernate Validator version ${hibernate-validator.version} and its dependencies repackaged as OSGi bundle</description>
+
+    <developers>
+        <developer>
+            <id>ss141213</id>
+            <name>Sahoo</name>
+            <organization>Sun Microsystems, Inc.</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>
+                            <!-- Only specify root artifacts that need to be embedded, everything else
+                            will be pulled in automatically based on Private-Package settings. -->
+                            *; artifactId=hibernate-validator; inline=true
+                        </Embed-Dependency>
+                        <Export-Package>
+                            javax.validation.*; version=${javax.validation.osgi.version},
+                            org.hibernate.validator.*; version=${hibernate-validator.version},
+                            org.glassfish.validation; version=${hibernate-validator.version}
+                        </Export-Package>
+
+                        <Private-Package>
+                            <!-- JBoss logging is used by Hibernate Validator as of version 4.3.0.Final.
+                                 We must repackage it privately in this bundle.
+                            -->
+                            org.jboss.logging.*,com.fasterxml.*
+                        </Private-Package>
+
+                        <Import-Package>
+                            <!--
+                                - bean validator has optional dependency on JPA API. More over, it relies on
+                                JPA 2.0, as it tries to dynamically load javax.persistence.PersistenceUtil.class,
+                                which is a JPA 2 class.
+                                - jboss.logging has the following optional dependencies (see manifest in
+                                jboss-logging-*.jar):
+                                org.apache.log4j, org.jboss.logmanager, org.slf4j, org.slf4j.spi
+                                - Hibernate Validator has optional dependencies on (see manifest in
+                                hibernate-validator-*.jar): javax.persistence, org.joda.time, org.jsoup, org.jsoup.safety
+                            javax.enterprise.inject.*; resolution:=optional,
+                            -->
+                            org.slf4j; org.slf4j.spi; org.slf4j.helpers; version=${slf4j.version}; resolution:=optional,
+                            javax.persistence.*; version="2.0"; resolution:=optional,
+                            org.joda.time; resolution:=optional; version="[1.6.0,2.0.0)",
+                            org.jsoup.*; resolution:=optional; version="[1.5.2,2.0.0)",
+                            org.apache.log4j; resolution:=optional,
+                            org.jboss.logmanager; resolution:=optional,
+                            javax.el;version="[2.2,3]",
+                            javax.enterprise.inject.*; resolution:=optional,
+                            javax.enterprise.context.*; resolution:=optional,
+                            javax.enterprise.event.*; resolution:=optional,
+                            javax.enterprise.util.*; resolution:=optional,
+                            javax.interceptor.*; resolution:=optional,
+                            com.thoughtworks.paranamer.*; resolution:=optional,
+                            javafx.beans.value.*; resolution:=optional,
+                            org.apache.logging.log4j.*; resolution:=optional,
+                            org.hibernate.validator.*; version=${hibernate-validator.version},
+                            *
+                        </Import-Package>
+                        <!--
+                        See https://hibernate.onjira.com/browse/HV-562 which I have filed against hibernate validator.
+                        It's a bug in hibernate validator the way it detects JPA. It uses thread's context classloader to
+                        see if JPA classes are available and then goes onto instantiate its JPATraversableResolver which
+                        has staic dependency on JPA classes. It should have used its own class loader to detect existence
+                        of JPA classes. If we don't add this DynamicImport-Package, what could happen is that at the time
+                        of resolution of hibernate-validator, it's optional dependency on javax.persistence may not be
+                        satisfied, so this bundle won't be able to load jpa classes, yet when it uses TCL to detect JPA,
+                        that might return true. Based on this outcome, it could go onto use JPATraversableResolver and
+                        eventually fail with NCDFE. Adding a DynamicImport-Package helps rewiring this bundle to JPA late.
+                        -->
+                        <DynamicImport-Package>javax.persistence; javax.persistence.*;  version="2.0"</DynamicImport-Package>
+                        <Implementation-Version>
+                            ${hibernate-validator.version}
+                        </Implementation-Version>
+                    </instructions>
+                    <!-- Maven uses the output directory (target/classes)
+                    rather than the final bundle, when compiling against
+                    projects in the same reactor (ie. the same build).
+                    Since this jar comprises of classes that come from
+                    some other jar and other modules depend on this
+                    artifact, we need to unpack.
+                    -->
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-sources</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-validator</artifactId>
+                                    <version>${hibernate-validator.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>            
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <!-- 
+                Although hibernate validator uses maven-shade-plugin to repackage com.googlecode.jtype classes
+                bu org.hibernate.validator.jtype classes, the shade plugin seems to leave behind some 
+                constant pool entries referring to google classes, so we need to package google jtype classes as well.
+                I have asked Emmanuel Bernard about this. It appears to be a bug in shade plugin or HV.
+                Because of shade-plugin, the dependency is remove from hibernate-validator pom, so we need to add it
+                here so that we can package these classes.
+            -->
+            <groupId>com.googlecode.jtype</groupId>
+            <artifactId>jtype</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/nucleus/packager/external/pom.xml
+++ b/nucleus/packager/external/pom.xml
@@ -71,6 +71,8 @@
         <module>trilead-ssh2</module>
         <module>j-interop</module>
 	<module>antlr</module>
+        <module>bean-validator</module>
+        <module>bean-validator-cdi</module>
     </modules>
     <build>
         <plugins>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -94,18 +94,19 @@
             <groupId>org.glassfish.external</groupId>
             <artifactId>asm-all</artifactId>
         </dependency>
-        <dependency>
+<!--        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-        </dependency>
+        </dependency>-->
         <dependency>
-   	    <groupId>org.glassfish.hk2.external</groupId>
+   	    <groupId>org.glassfish.main.external</groupId>
             <artifactId>bean-validator</artifactId>
-	    <version>${bean.validator.version}</version>
+	    <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
+            <groupId>org.glassfish.main.external</groupId>
+            <artifactId>bean-validator-cdi</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -99,13 +99,14 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-   	    <groupId>org.glassfish.hk2.external</groupId>
+   	    <groupId>org.glassfish.main.external</groupId>
             <artifactId>bean-validator</artifactId>
-	    <version>${bean.validator.version}</version>
+	    <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
+            <groupId>org.glassfish.main.external</groupId>
+            <artifactId>bean-validator-cdi</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -124,6 +124,8 @@
 
         <glassfish-corba.version>4.0.1</glassfish-corba.version>
         <stax-api.version>1.0-2</stax-api.version>
+        <slf4j.version>1.7.21</slf4j.version>
+        <javax.validation.osgi.version>1.1.0</javax.validation.osgi.version>
         <management-api.version>1.1-rev-1</management-api.version>
         <servlet-api.version>4.0.0-b07</servlet-api.version>
         <grizzly.version>2.4.0-beta8</grizzly.version>
@@ -148,6 +150,7 @@
         <jettison.version>1.3.3</jettison.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1-m08</jax-rs-api.impl.version>
+        <jtype.version>0.1.0</jtype.version>
         <mimepull.version>1.9.4</mimepull.version>
         <jbi.version>1.0</jbi.version>
         <glassfish-management-api.version>3.2.1-b002</glassfish-management-api.version>
@@ -171,7 +174,6 @@
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
-	<bean.validator.version>2.5.0-b06</bean.validator.version>
     </properties>
 
     <modules>
@@ -692,6 +694,21 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
+            </dependency>
+           <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-validator-cdi</artifactId>
+                <version>${hibernate-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
+            </dependency>
+             <dependency>
+                <groupId>com.googlecode.jtype</groupId>
+                <artifactId>jtype</artifactId>
+                <version>${jtype.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml</groupId>


### PR DESCRIPTION
Fixes #21894
Please refer issue https://github.com/javaee/glassfish/issues/21894 for all description.
(Same changes as that of PR https://github.com/javaee/glassfish/pull/21911, but with updated copyright headers for the new files and submitting as a single commit).
