### PR TITLE
Fix for #21832: asadmin list-jdbc-connection-pools or list-connector-connection-pools subcommand always output CLI031 warning message

### DIFF
--- a/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ListConnectorConnectionPools.java
+++ b/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ListConnectorConnectionPools.java
@@ -84,7 +84,7 @@ public class ListConnectorConnectionPools implements AdminCommand {
     @Inject
     private Domain domain;
 
-    @Param(primary = true, optional = true, defaultValue = SystemPropertyConstants.DAS_SERVER_NAME, alias = "targetName", obsolete = true)
+    @Param(primary = true, optional = true, alias = "targetName", obsolete = true)
     private String target ;
     
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/ListJdbcConnectionPools.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/ListJdbcConnectionPools.java
@@ -87,7 +87,7 @@ public class ListJdbcConnectionPools implements AdminCommand {
     @Inject
     private Domain domain;
 
-    @Param(primary = true, optional = true, defaultValue = SystemPropertyConstants.DAS_SERVER_NAME, alias = "targetName", obsolete = true)
+    @Param(primary = true, optional = true, alias = "targetName", obsolete = true)
     private String target ;
 
 


### PR DESCRIPTION
Fixes #21832 : Removing default value of @Param on target field