### PR TITLE
Fix for #21874: update-connector-security-map can't delete backend principal password

### DIFF
--- a/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/UpdateConnectorSecurityMap.java
+++ b/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/UpdateConnectorSecurityMap.java
@@ -371,8 +371,12 @@ public class UpdateConnectorSecurityMap extends ConnectorSecurityMap implements 
                     if (mappedusername != null && !mappedusername.isEmpty()) {
                         bp.setUserName(mappedusername);
                     }
-                    if (mappedpassword != null && !mappedpassword.isEmpty()) {
-                        bp.setPassword(mappedpassword);
+                    if (mappedpassword != null) {
+                        if(mappedpassword.isEmpty()) {
+                            bp.setPassword(null);
+                        } else {
+                            bp.setPassword(mappedpassword);
+                        }
                     }
 
                     return sm;


### PR DESCRIPTION
Fixes #21874: The problem is if someone executes update-connector-security-map with --passwordfile that contains "AS_ADMIN_MAPPEDPASSWORD=",(i.e an empty string) command returns success.
But actually, connector security map's backend principal password doesn't gets changed.

The below changes solves the problem.