### PR TITLE
#21722 Integrate Mojarra 2.3.2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -65,7 +65,7 @@
         <jsp-impl.version>2.3.3-b02</jsp-impl.version>
         <jstl-impl.version>1.2.5-b03</jstl-impl.version>
         <jstl-api.version>1.2.1</jstl-api.version>
-        <mojarra.version>2.3.1</mojarra.version>
+        <mojarra.version>2.3.2</mojarra.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>4.0.2.10</woodstock.version>
         <javax.ejb-api.version>3.2</javax.ejb-api.version>


### PR DESCRIPTION
For #21722 this integrates Mojarra 2.3.2, which remove the context-param for server push, causing all JSF resources to be pushed if HTTP/2 is the current protocol.