### PR TITLE
Jersey 2.26-b07

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -145,7 +145,7 @@
         <gmbal.version>4.0.0-b001</gmbal.version>
         <woodstox.version>4.1.2</woodstox.version>
         <antlr.version>2.7.6</antlr.version>
-        <jersey.version>2.26-b06</jersey.version>
+        <jersey.version>2.26-b07</jersey.version>
         <jackson.version>2.8.4</jackson.version>
         <jettison.version>1.3.3</jettison.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>


### PR DESCRIPTION
- fixed OSGi dependency - allowing BeanValidation API version [1.1, 3).