### PR TITLE
Fixes #21969: integrate Metro-2.4.0-b170703.2107

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -103,12 +103,12 @@
         <jsftemplating.version>2.1.2</jsftemplating.version>
         <uc-pkg-client.version>1.122-57.2889</uc-pkg-client.version>
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
-        <webservices.version>2.4.0-b170626.1307</webservices.version>
+        <webservices.version>2.4.0-b170703.2107</webservices.version>
         <jsr181-api.version>1.0-MR1</jsr181-api.version>
-        <woodstox.version>4.2.0</woodstox.version>
+        <woodstox.version>4.4.1</woodstox.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
         <jaxb.version>2.3.0-b170624.2321</jaxb.version>
-        <stax2-api.version>3.1.1</stax2-api.version>
+        <stax2-api.version>3.1.4</stax2-api.version>
         <javax.xml.registry-api.version>1.0.7</javax.xml.registry-api.version>
         <eclipselink.version>2.6.3-M1</eclipselink.version>
         <javax-persistence-api.version>2.1.0</javax-persistence-api.version> 

--- a/appserver/tests/appserv-tests/devtests/security/jmac/soap/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jmac/soap/build.xml
@@ -57,11 +57,7 @@
     &testproperties;
     &commonSecurity;
 
-    <!--<target name="all" depends="clean, build-providers, setup, build-deploy, run, undeploy, unsetup"/>-->
-    <target name="all">
-        <echo message="FIXME: failing test due to a bug in saaj-ri 1.4.0-b11" />
-        <echo message="Known failure see IDCINTER-82"/>
-    </target>
+    <target name="all" depends="clean, build-providers, setup, build-deploy, run, undeploy, unsetup"/>
 
     <target name="clean" depends="init-common">
       <antcall target="clean-common"/>

--- a/appserver/tests/appserv-tests/devtests/security/wss/encThenSign-default-conf/servletws/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/wss/encThenSign-default-conf/servletws/build.xml
@@ -55,12 +55,8 @@
     &testproperties;
     &commonSecurity;
 
-    <!--<target name="all" 
-    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>-->
-    <target name="all" depends="clean">
-      <echo message="FIXME: Known failure."/>
-    </target>
-    
+    <target name="all"
+    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>
 
     <target name="run-test" 
     depends="clean, build, deploy, run, undeploy"/>

--- a/appserver/tests/appserv-tests/devtests/security/wss/permethod/servletws/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/wss/permethod/servletws/build.xml
@@ -55,11 +55,8 @@
     &testproperties;
     &commonSecurity;
 
-    <!--<target name="all" 
-    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>-->
-    <target name="all" depends="clean">
-      <echo message="FIXME: Known failure."/>
-    </target>
+    <target name="all"
+    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>
 
     <target name="run-test" 
     depends="clean, build, deploy, run, undeploy"/>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -130,7 +130,7 @@
         <servlet-api.version>4.0.0-b07</servlet-api.version>
         <grizzly.version>2.4.0-beta8</grizzly.version>
         <grizzly.npn.version>1.7</grizzly.npn.version>
-        <saaj-api.version>1.3.4</saaj-api.version>
+        <saaj-api.version>1.4.0</saaj-api.version>
         <hk2.version>2.5.0-b36</hk2.version>
         <hk2.plugin.version>2.5.0-b33</hk2.plugin.version>
         <jboss.logging.version>3.3.1.Final</jboss.logging.version>
@@ -143,7 +143,6 @@
         <trilead-ssh2.version>build212-hudson-6</trilead-ssh2.version>
         <pfl.version>4.0.0-b004</pfl.version>
         <gmbal.version>4.0.0-b001</gmbal.version>
-        <woodstox.version>4.1.2</woodstox.version>
         <antlr.version>2.7.6</antlr.version>
         <jersey.version>2.26-b07</jersey.version>
         <jackson.version>2.8.4</jackson.version>


### PR DESCRIPTION
Fixes #21969:
* fix failing and currently disabled security related devtests
* fix incorrect version of soap-api property in nucleus/pom.xml
* update SAAJ RI to 1.4.0
* update woodstox parser to 4.4.1
* update stax2-api to 3.1.4