### PR TITLE
Fix for #21909: Error message 'Flashlight listener registration failed  for listener class'  is found in server.log when EJB monitoring is HIGH

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -4801,7 +4801,7 @@ public abstract class BaseContainer
 	String appName = null;
 	String modName = null;
 	String ejbName = null;
-    boolean isMonitorRegistryMediatorCreated = false;
+    	boolean isMonitorRegistryMediatorCreated = false;
 	try {
 	    appName = (ejbDescriptor.getApplication().isVirtual())
 		? null: ejbDescriptor.getApplication().getRegistrationName();

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -4801,6 +4801,7 @@ public abstract class BaseContainer
 	String appName = null;
 	String modName = null;
 	String ejbName = null;
+    boolean isMonitorRegistryMediatorCreated = false;
 	try {
 	    appName = (ejbDescriptor.getApplication().isVirtual())
 		? null: ejbDescriptor.getApplication().getRegistrationName();
@@ -4815,6 +4816,8 @@ public abstract class BaseContainer
 	    ejbName = ejbDescriptor.getName();
             containerInfo = new ContainerInfo(appName, modName, ejbName);
 
+            isMonitorRegistryMediatorCreated = true;
+            registerEjbMonitoringProbeProvider(appName, modName, ejbName);
             ejbProbeListener = getMonitoringStatsProvider(appName, modName, ejbName);
             ejbProbeListener.addMethods(getContainerId(), appName, modName, ejbName, getMonitoringMethodsArray());
             ejbProbeListener.register();
@@ -4825,8 +4828,13 @@ public abstract class BaseContainer
             }
 	} catch (Exception ex) {
 	    _logger.log(Level.SEVERE, COULD_NOT_CREATE_MONITORREGISTRYMEDIATOR, new Object[]{EjbMonitoringUtils.getDetailedLoggingName(appName, modName, ejbName), ex});
+	    if (!isMonitorRegistryMediatorCreated) {
+	        registerEjbMonitoringProbeProvider(appName, modName, ejbName);
+	    }
+	}
 	}
 
+    private void registerEjbMonitoringProbeProvider(String appName, String modName, String ejbName) {
         // Always create to avoid NPE
         try {
             ProbeProviderFactory probeFactory = ejbContainerUtilImpl.getProbeProviderFactory();

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
@@ -526,7 +526,9 @@ public final class StatefulSessionContainer
             sfsbStoreMonitor = new StatefulSessionStoreMonitor();
         }
         sessionBeanCache.setStatefulSessionStoreMonitor(sfsbStoreMonitor);
-        _logger.log(Level.FINE, "[SFSBContainer] registered monitorable");
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "[SFSBContainer] registered monitorable");
+        }
     }
 
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/StatefulSessionContainer.java
@@ -513,26 +513,12 @@ public final class StatefulSessionContainer
     }
 
     protected void registerMonitorableComponents() {
+        registerEjbCacheProbeProvider();
         super.registerMonitorableComponents();
         cacheProbeListener = new EjbCacheStatsProvider(sessionBeanCache,
                 getContainerId(), containerInfo.appName, containerInfo.modName,
                 containerInfo.ejbName);
         cacheProbeListener.register();
-
-        try {
-            ProbeProviderFactory probeFactory = ejbContainerUtilImpl.getProbeProviderFactory();
-            String invokerId = EjbMonitoringUtils.getInvokerId(containerInfo.appName,
-                    containerInfo.modName, containerInfo.ejbName);
-            cacheProbeNotifier = probeFactory.getProbeProvider(EjbCacheProbeProvider.class, invokerId);
-            if (_logger.isLoggable(Level.FINE)) {
-                _logger.log(Level.FINE, "Got ProbeProvider: " + cacheProbeNotifier.getClass().getName());
-            }
-        } catch (Exception ex) {
-            cacheProbeNotifier = new EjbCacheProbeProvider();
-            if (_logger.isLoggable(Level.FINE)) {
-                _logger.log(Level.FINE, "Error getting the EjbMonitoringProbeProvider");
-            }
-        }
 
         if (isHAEnabled) {
             sfsbStoreMonitor = new HAStatefulSessionStoreMonitor();
@@ -541,6 +527,39 @@ public final class StatefulSessionContainer
         }
         sessionBeanCache.setStatefulSessionStoreMonitor(sfsbStoreMonitor);
         _logger.log(Level.FINE, "[SFSBContainer] registered monitorable");
+    }
+
+
+    private void registerEjbCacheProbeProvider() {
+        String appName = null;
+        String modName = null;
+        String ejbName = null;
+
+        try {
+            appName = (ejbDescriptor.getApplication().isVirtual()) ? null
+                    : ejbDescriptor.getApplication().getRegistrationName();
+            if (appName == null) {
+                modName = ejbDescriptor.getApplication().getRegistrationName();
+            } else {
+                String archiveuri = ejbDescriptor.getEjbBundleDescriptor()
+                        .getModuleDescriptor().getArchiveUri();
+                modName = com.sun.enterprise.util.io.FileUtils
+                        .makeFriendlyFilename(archiveuri);
+            }
+            ejbName = ejbDescriptor.getName();
+
+            ProbeProviderFactory probeFactory = ejbContainerUtilImpl.getProbeProviderFactory();
+            String invokerId = EjbMonitoringUtils.getInvokerId(appName, modName, ejbName);
+            cacheProbeNotifier = probeFactory.getProbeProvider(EjbCacheProbeProvider.class, invokerId);
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.log(Level.FINE, "Got ProbeProvider: " + cacheProbeNotifier.getClass().getName());
+            }
+        } catch (Exception ex) {
+            cacheProbeNotifier = new EjbCacheProbeProvider();
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.log(Level.FINE, "Error getting the EjbCacheProbeProvider");
+            }
+        }
     }
 
     public String getMonitorAttributeValues() {


### PR DESCRIPTION
Fix for #21909: Error message 'Flashlight listener registration failed  for listener class'  is found in server.log when EJB monitoring is HIGH