### PR TITLE
Splitting the tests of admin cli project in order to reducr run time

### DIFF
--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -162,7 +162,7 @@
         <record name="admin.output" action="stop" />
         <antcall target="stacker"/>
         <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results_cli_group_1.html"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
     <target name="cli-group-2-master" depends="clean,init">
@@ -172,7 +172,7 @@
         <record name="admin.output" action="stop" />
         <antcall target="stacker"/>
         <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results_cli_group_2.html"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -148,11 +148,12 @@
 
    <!-- modification for splitting test -->
       
-    <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance, cluster,
-                        configs, sync, domain, backup, tokens, validation, node,teardown"/>
-   <target name="cli-group-2" depends="setup,logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
+    <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance,teardown"/>
+     <target name="cli-group-2" depends="setup,cluster,configs, sync, domain,teardown"/>
+    <target name="cli-group-3" depends="setup,backup, tokens, validation, node,teardown"/>
+   <target name="cli-group-4" depends="setup,logging-command,load-balancer, getset, misc-commands, teardown"/>
+    <target name="cli-group-5" depends="setup,all-jms, manual-sync, upgrade,
                         restart-domain, config-modularity, teardown"/>
-
 
 
      <target name="cli-group-1-master" depends="clean,init">
@@ -168,13 +169,42 @@
     <target name="cli-group-2-master" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
-        <antcall target="cli-group-2-master"/>
+        <antcall target="cli-group-2"/>
         <record name="admin.output" action="stop" />
         <antcall target="stacker"/>
         <antcall target="dev-report"/>
         <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
+   <target name="cli-group-3-master" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-3"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+  <target name="cli-group-4-master" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-4"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+ <target name="cli-group-5-master" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-5"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
 
 
    <!-- modification for splitting test -->

--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -156,7 +156,7 @@
                         restart-domain, config-modularity, teardown"/>
 
 
-     <target name="cli-group-1-master" depends="clean,init">
+     <target name="admin-cli-group-1" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
         <antcall target="cli-group-1"/>
@@ -166,7 +166,7 @@
         <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
-    <target name="cli-group-2-master" depends="clean,init">
+    <target name="admin-cli-group-2" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
         <antcall target="cli-group-2"/>
@@ -176,7 +176,7 @@
         <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
-   <target name="cli-group-3-master" depends="clean,init">
+   <target name="admin-cli-group-3" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
         <antcall target="cli-group-3"/>
@@ -186,7 +186,7 @@
         <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
-  <target name="cli-group-4-master" depends="clean,init">
+  <target name="admin-cli-group-4" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
         <antcall target="cli-group-4"/>
@@ -196,7 +196,7 @@
         <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
     </target>
 
- <target name="cli-group-5-master" depends="clean,init">
+ <target name="admin-cli-group-5" depends="clean,init">
         <record name="admin.output" action="start" />
         <antcall target="prerun"/>
         <antcall target="cli-group-5"/>

--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -146,7 +146,42 @@
                         logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
                         restart-domain, config-modularity, teardown"/>
 
-    <target name="cluster" depends="init">
+   <!-- modification for splitting test -->
+      
+    <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance, cluster,
+                        configs, sync, domain, backup, tokens, validation, node,teardown"/>
+   <target name="cli-group-2" depends="setup,logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
+                        restart-domain, config-modularity, teardown"/>
+
+
+
+     <target name="cli-group-1-master" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-1"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results_cli_group_1.html"/>
+    </target>
+
+    <target name="cli-group-2-master" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-2-master"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results_cli_group_2.html"/>
+    </target>
+
+
+
+   <!-- modification for splitting test -->
+   
+   
+
+   <target name="cluster" depends="init">
         <runtest classname="admin.ClusterTest"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -86,7 +86,7 @@ get_test_target(){
 }
 
 list_test_ids(){
-	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin- cli-group-4 admin-cli-group-5
+	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin-cli-group-4 admin-cli-group-5
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -78,11 +78,8 @@ get_test_target(){
 		admin_cli_all )
 			TARGET=all
 			export TARGET;;
-	       cli-group-1 )
-                       TARGET=cli-group-1-master
-                       export TARGET;;
-               cli-group-2 )
-                       TARGET=cli-group-2-master
+	        * )
+                       TARGET=$1
                        export TARGET;;
         esac
 
@@ -92,6 +89,9 @@ list_test_ids(){
 	echo admin_cli_all
         echo cli-group-1-master
         echo cli-group-2-master
+        echo cli-group-3-master
+        echo cli-group-4-master
+        echo cli-group-5-master
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -86,12 +86,7 @@ get_test_target(){
 }
 
 list_test_ids(){
-	echo admin_cli_all
-        echo cli-group-1-master
-        echo cli-group-2-master
-        echo cli-group-3-master
-        echo cli-group-4-master
-        echo cli-group-5-master
+	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin- cli-group-4 admin-cli-group-5
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -78,7 +78,13 @@ get_test_target(){
 		admin_cli_all )
 			TARGET=all
 			export TARGET;;
-	esac
+	       cli-group-1 )
+                       TARGET=cli-group-1-master
+                       export TARGET;;
+               cli-group-2 )
+                       TARGET=cli-group-2-master
+                       export TARGET;;
+        esac
 
 }
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -90,6 +90,8 @@ get_test_target(){
 
 list_test_ids(){
 	echo admin_cli_all
+        echo cli-group-1-master
+        echo cli-group-2-master
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/build.xml
@@ -183,7 +183,7 @@
         <ant dir="allowedmethods" target="all"/>
     </target>
 
-    <target name="test-group-4>
+    <target name="test-group-4">
         <ant dir="jms" target="all"/>
         <ant dir="ejb32" target="all"/>
         <ant dir="ejb31" target="all"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/build.xml
@@ -94,18 +94,6 @@
         <antcall target="report"/>
     </target>
 
-      <target name="ejb_group_4">
-        <antcall target="setup"/>
-        <antcall target="test-group-4"/>
-        <antcall target="unsetup"/>
-        <antcall target="report"/>
-    </target>
-
-
-
-     
-
-
     <target name="lite">
 
 	<antcall target="setup"/>
@@ -181,9 +169,6 @@
         <ant dir="cmp" target="all"/>
         <ant dir="sfsb" target="all"/>
         <ant dir="allowedmethods" target="all"/>
-    </target>
-
-    <target name="test-group-4">
         <ant dir="jms" target="all"/>
         <ant dir="ejb32" target="all"/>
         <ant dir="ejb31" target="all"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/build.xml
@@ -94,6 +94,13 @@
         <antcall target="report"/>
     </target>
 
+      <target name="ejb_group_4">
+        <antcall target="setup"/>
+        <antcall target="test-group-4"/>
+        <antcall target="unsetup"/>
+        <antcall target="report"/>
+    </target>
+
 
 
      
@@ -174,6 +181,9 @@
         <ant dir="cmp" target="all"/>
         <ant dir="sfsb" target="all"/>
         <ant dir="allowedmethods" target="all"/>
+    </target>
+
+    <target name="test-group-4>
         <ant dir="jms" target="all"/>
         <ant dir="ejb32" target="all"/>
         <ant dir="ejb31" target="all"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/build.xml
@@ -72,6 +72,33 @@
         <antcall target="report"/>
     </target>
 
+     <target name="ejb_group_1">
+
+        <antcall target="setup"/>
+        <antcall target="test-group-1"/>
+        <antcall target="unsetup"/>
+        <antcall target="report"/>
+    </target>
+
+      <target name="ejb_group_2">
+        <antcall target="setup"/>
+        <antcall target="test-group-2"/>
+        <antcall target="unsetup"/>
+        <antcall target="report"/>
+    </target>
+
+      <target name="ejb_group_3">
+        <antcall target="setup"/>
+        <antcall target="test-group-3"/>
+        <antcall target="unsetup"/>
+        <antcall target="report"/>
+    </target>
+
+
+
+     
+
+
     <target name="lite">
 
 	<antcall target="setup"/>
@@ -127,7 +154,33 @@
         <ant dir="ejb31" target="all"/>
 
     </target>
+    
 
+    <target name="test-group-1">
+        <ant dir="stubs" target="all"/>
+        <ant dir="txprop" target="all"/>
+        <ant dir="ejbc" target="all"/>
+        <ant dir="ejb30" target="all"/>
+    </target>
+    
+    <target name="test-group-2">
+        <ant dir="mdb" target="all"/>
+        <ant dir="cli" target="all"/>
+        <ant dir="timer" target="all"/>
+        <ant dir="bmp" target="all"/>
+    </target>
+
+      <target name="test-group-3">
+        <ant dir="cmp" target="all"/>
+        <ant dir="sfsb" target="all"/>
+        <ant dir="allowedmethods" target="all"/>
+        <ant dir="jms" target="all"/>
+        <ant dir="ejb32" target="all"/>
+        <ant dir="ejb31" target="all"/>
+    </target>
+
+
+    
     <target name="unsetup">
         <echo message="Stopping app server instance"/>
         <ant target="stopDomain"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
@@ -276,6 +276,8 @@ get_test_target(){
 			TARGET=all ;;
 		ejb_web_all)
 			TARGET=lite ;;
+                * )
+                       TARGET=$1 ;;
 	esac
 	export TARGET
 
@@ -318,7 +320,7 @@ run_test_id(){
 
 
 list_test_ids(){
-	echo ejb_all ejb_timer_cluster_all ejb_web_all
+	echo ejb_all ejb_timer_cluster_all ejb_web_all ejb_group_1 ejb_group_2 ejb_group_3
 }
 
 OPT=$1
@@ -329,4 +331,5 @@ case $OPT in
 		list_test_ids;;
 	run_test_id )
 		run_test_id $TEST_ID ;;
+        
 esac

--- a/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
@@ -299,7 +299,7 @@ run_test_id(){
 	cd `dirname $0`
 	test_init
 	get_test_target $1
-	if [[ $1 = "ejb_all" ]]; then
+	if [[ $1 = "ejb_all" ] -o [ $1 = ejb_group* ]]; then
 		test_run_ejb
 	elif [[ $1 = "ejb_timer_cluster_all" ]]; then
 		test_run_ejb_timer_cluster

--- a/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
@@ -299,7 +299,7 @@ run_test_id(){
 	cd `dirname $0`
 	test_init
 	get_test_target $1
-	if [[ $1 = "ejb_all" ] -o [ $1 = ejb_group* ]]; then
+	if [[ $1 = "ejb_all" || $1 = "ejb_group"* ]]; then
 		test_run_ejb
 	elif [[ $1 = "ejb_timer_cluster_all" ]]; then
 		test_run_ejb_timer_cluster

--- a/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
@@ -320,7 +320,7 @@ run_test_id(){
 
 
 list_test_ids(){
-	echo ejb_all ejb_timer_cluster_all ejb_web_all ejb_group_1 ejb_group_2 ejb_group_3
+	echo ejb_all ejb_timer_cluster_all ejb_web_all ejb_group_1 ejb_group_2 ejb_group_3 ejb_group_4
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/ejb/run_test.sh
@@ -320,7 +320,7 @@ run_test_id(){
 
 
 list_test_ids(){
-	echo ejb_all ejb_timer_cluster_all ejb_web_all ejb_group_1 ejb_group_2 ejb_group_3 ejb_group_4
+	echo ejb_all ejb_timer_cluster_all ejb_web_all ejb_group_1 ejb_group_2 ejb_group_3
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/build.xml
@@ -117,13 +117,22 @@
 
         <record name="transaction.ee.output" action="start" />
         <ant dir="timer_with_autorecovery" target="test"/>
-        <ant dir="dblogs" target="test"/>
 
         <antcall target="stop"/>
 
         <record name="transaction.ee.output" action="stop" />
         <antcall target="dev-report"/>
 
+    </target>
+
+    <target name="transaction-ee-4">
+        <antcall target="clean-results"/>
+        <antcall target="start"/>
+        <record name="transaction.ee.output" action="start" />
+        <ant dir="dblogs" target="test"/>
+        <antcall target="stop"/>
+        <record name="transaction.ee.output" action="stop" />
+        <antcall target="dev-report"/>
     </target>
 
 

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/build.xml
@@ -78,6 +78,57 @@
 
     </target>
 
+
+    <target name="transaction-ee-1">
+        <antcall target="clean-results"/>
+        <antcall target="start"/>
+
+        <record name="transaction.ee.output" action="start" />
+
+        <ant dir="selfrecovery" target="test"/>
+        <ant dir="autorecovery" target="test"/>
+        <ant dir="cli" target="test"/>
+
+        <antcall target="stop"/>
+
+        <record name="transaction.ee.output" action="stop" />
+        <antcall target="dev-report"/>
+
+    </target>
+
+    <target name="transaction-ee-2">
+        <antcall target="clean-results"/>
+        <antcall target="start"/>
+
+        <record name="transaction.ee.output" action="start" />
+
+        <ant dir="mdb" target="test"/>
+        <ant dir="resendautorecovery" target="test"/>
+
+        <antcall target="stop"/>
+
+        <record name="transaction.ee.output" action="stop" />
+        <antcall target="dev-report"/>
+
+    </target>
+    <target name="transaction-ee-3">
+        <antcall target="clean-results"/>
+        <antcall target="start"/>
+
+        <record name="transaction.ee.output" action="start" />
+        <ant dir="timer_with_autorecovery" target="test"/>
+        <ant dir="dblogs" target="test"/>
+
+        <antcall target="stop"/>
+
+        <record name="transaction.ee.output" action="stop" />
+        <antcall target="dev-report"/>
+
+    </target>
+
+
+
+
     <target name="start">
         <antcall target="start-derby"/>
         <antcall target="start-domain"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
@@ -115,6 +115,9 @@ test_run(){
 
 list_test_ids(){
     echo transaction_ee_all
+    echo transaction-ee-1
+    echo transaction-ee-2
+    echo transaction-ee-3
 }
 
 get_test_target(){
@@ -122,6 +125,9 @@ get_test_target(){
 		transaction_ee_all )
 			TARGET=all
 			export TARGET;;
+                * )
+                        TARGET=*
+                        export TARGET;;
 	esac
 
 }

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
@@ -126,7 +126,7 @@ get_test_target(){
 			TARGET=all
 			export TARGET;;
                 * )
-                        TARGET=*
+                        TARGET=$1
                         export TARGET;;
 	esac
 

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/run_test.sh
@@ -118,6 +118,7 @@ list_test_ids(){
     echo transaction-ee-1
     echo transaction-ee-2
     echo transaction-ee-3
+    echo transaction-ee-4
 }
 
 get_test_target(){

--- a/appserver/tests/appserv-tests/devtests/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/build.xml
@@ -166,7 +166,7 @@
         <antcall target="finish-report"/>
     </target>
 
-    <target name="servlet" depends="init-report">
+    <target name="servlet-1" depends="init-report">
         <ant dir="applicationDispatcher" target="all"/>
         <ant dir="cacheControlResponseHeaders" target="all"/>
         <ant dir="cacheFilterMappingDispatcher" target="all"/>
@@ -182,7 +182,11 @@
         <ant dir="servletInitBeforeGetServletConfig" target="all"/>
         <ant dir="listenerFilterServletInit" target="all"/>  
         <ant dir="filterMultipleInit" target="all"/>  
-        <ant dir="filterURIMapping" target="all"/>
+        <antcall target="finish-report"/>
+    </target>
+
+    <target name="servlet-2" depends="init-report">
+    <ant dir="filterURIMapping" target="all"/>
         <ant dir="forwardWithQueryString" target="all"/>
         <ant dir="getAttributeAfterForward" target="all"/>
         <ant dir="getAttributeAfterInclude" target="all"/>
@@ -197,7 +201,11 @@
         <ant dir="multiByteGETQueryParamDefaultCharset" target="all"/>
         <ant dir="multiByteGETQueryParamFormHintField" target="all"/>
         <ant dir="multiByteGETQueryParamLocaleCharsetMap" target="all"/>
-        <ant dir="multiByteGETQueryParamSetCharEncoding" target="all"/>
+     <antcall target="finish-report"/>
+    </target>
+    
+    <target name="servlet-3" depends="init-report">
+    <ant dir="multiByteGETQueryParamSetCharEncoding" target="all"/>
         <ant dir="multiBytePOSTFormHintField" target="all"/>
         <ant dir="multibyteValue" target="all"/>
         <ant dir="queryString" target="all"/>
@@ -212,7 +220,11 @@
         <ant dir="requestDispatcherMultipleForward" target="all"/>
         <ant dir="requestDispatcherPathWithParams" target="all"/>
         <ant dir="responseErrorMessageEncoding" target="all"/>
-        <ant dir="responseExceptionMessageEncoding" target="all"/>
+     <antcall target="finish-report"/>
+    </target>
+    
+    <target name="servlet-4" depends="init-report">
+   <ant dir="responseExceptionMessageEncoding" target="all"/>
         <ant dir="includeErrorPageAfterResponseCommit" target="all"/>
         <ant dir="reuseSessionId" target="all"/>
         <ant dir="securityConstraintWildcardMapping" target="all"/>
@@ -227,7 +239,11 @@
         <ant dir="servlet-3.0/asyncContextSetTimeout" target="all"/>
         <ant dir="servlet-3.0/asyncContextDispatchWithException" target="all"/>
         <ant dir="servlet-3.0/asyncListenerOnComplete" target="all"/>
-        <ant dir="servlet-3.0/asyncListenerOnError" target="all"/>
+    <antcall target="finish-report"/>
+    </target>
+
+   <target name="servlet-5" depends="init-report">
+   <ant dir="servlet-3.0/asyncListenerOnError" target="all"/>
         <ant dir="servlet-3.0/asyncListenerOnTimeout" target="all"/>
         <ant dir="servlet-3.0/asyncListenerOnTimeoutDispatch" target="all"/>
         <ant dir="servlet-3.0/asyncStartOutsideAsyncDispatchScope" target="all"/>
@@ -242,7 +258,11 @@
         <ant dir="servlet-3.0/javaxServletContextOrderedLibs" target="all"/>
         <ant dir="servlet-3.0/multiWebFragments" target="all"/>
         <ant dir="servlet-3.0/multiWebFragmentsResources" target="all"/>
-        <ant dir="servlet-3.0/multipart" target="all"/>
+    <antcall target="finish-report"/>
+    </target>
+    
+     <target name="servlet-6" depends="init-report">
+     <ant dir="servlet-3.0/multipart" target="all"/>
         <ant dir="servlet-3.0/relativeOrderingWebFragments" target="all"/>
         <ant dir="servlet-3.0/serveJspAndStaticResourceFromLocalJar" target="all"/>
         <ant dir="servlet-3.0/resourceURLFromLocalJar" target="all"/>
@@ -257,7 +277,11 @@
         <ant dir="servlet-3.0/servletContextAddServletAndFilterByInstance" target="all"/>
         <ant dir="servlet-3.0/servletContextAddServletOverrideDefaultAndJspServletMappings" target="all"/>
         <ant dir="servlet-3.0/servletContextCompletePreliminaryFilterRegistration" target="all"/>
-        <ant dir="servlet-3.0/servletContextCompletePreliminaryServletRegistration" target="all"/>
+      <antcall target="finish-report"/>
+    </target>
+    
+     <target name="servlet-7" depends="init-report">
+    <ant dir="servlet-3.0/servletContextCompletePreliminaryServletRegistration" target="all"/>
         <ant dir="servlet-3.0/servletContextCreateServletAndFilter" target="all"/>
         <ant dir="servlet-3.0/servletContextCreateServletWithServletSecurity" target="all"/>
         <ant dir="servlet-3.0/servletContextGetRealPathFromLocalJar" target="all"/>
@@ -272,7 +296,12 @@
         <ant dir="servlet-3.0/sessionCookieConfigDeclarative" target="all"/>
         <ant dir="servlet-3.0/sessionCookieConfigProgrammatic" target="all"/>
         <ant dir="servlet-3.0/sessionCookieCustomNameProgrammatic" target="all"/>
-        <ant dir="servlet-3.0/sessionCookieCustomNameSunWebXml" target="all"/>
+     <antcall target="finish-report"/>
+    </target>
+      
+     
+       <target name="servlet-8" depends="init-report">
+       <ant dir="servlet-3.0/sessionCookieCustomNameSunWebXml" target="all"/>
         <ant dir="servlet-3.0/sessionCookieCustomNameWebXmlSunWebXmlPrecedence" target="all"/>
         <ant dir="servlet-3.0/sessionIdUrlRewriteSessionTrackingMode" target="all"/>
         <ant dir="servlet-3.0/sessionIdUrlRewriteSessionTrackingModeCustomCookieName" target="all"/>
@@ -287,6 +316,10 @@
         <ant dir="servlet-3.0/webServletAnnotation" target="all"/>
         <ant dir="servlet-3.0/xmlOverrideAnnotation" target="all"/>
         <ant dir="servlet-3.0/xmlOverrideAnnotationWithWebFragment" target="all"/>
+      <antcall target="finish-report"/>
+    </target>
+
+      <target name="servlet-9" depends="init-report">
         <ant dir="servlet-3.0/xmlOverrideUrlPatternWithWebFragment" target="all"/>
         <ant dir="servlet-3.0/filterWithEmptyUrl" target="all"/>
         <ant dir="servletAnnotationPreDestroy" target="all"/>
@@ -302,6 +335,10 @@
         <ant dir="servletFilterDefaultInvocationOrder" target="all"/>
         <ant dir="servletFilterMappingWithServletNameAndURLPattern" target="all"/>
         <ant dir="servletGetServerPort" target="all"/>
+        <antcall target="finish-report"/>
+    </target>
+
+      <target name="servlet-10" depends="init-report">
         <ant dir="servletLoadOnStartupMultipleInit" target="all"/>
         <ant dir="servletMappingWithMultipleURLPatterns" target="all"/>
         <ant dir="servletRelativeContextURLsEquals" target="all"/>
@@ -317,6 +354,10 @@
         <ant dir="servletResourceInjectionHttpSessionListener" target="all"/>
         <ant dir="servletResourceInjectionRequestAttributeListener" target="all"/>
         <ant dir="servletResourceInjectionRequestListener" target="all"/>
+       <antcall target="finish-report"/>
+    </target>
+
+       <target name="servlet-11" depends="init-report">
         <ant dir="servletResourceInjectionServletInstance" target="all"/>
         <ant dir="servletResourceInjectionServletInstanceLoadOnStartup" target="all"/>
         <ant dir="servletResponseQuotedContentTypeImbalance" target="all"/>
@@ -332,6 +373,11 @@
         <ant dir="sessionSetMaxInactiveIntervalExpire" target="all"/>
         <ant dir="sessionSetMaxInactiveIntervalToZeroAndInvalidate" target="all"/>
         <ant dir="setMultiValuedResponseHeader" target="all"/>
+         <antcall target="finish-report"/>
+    </target>
+
+
+       <target name="servlet-12" depends="init-report">       
         <ant dir="standalonewar" target="all"/>  
         <ant dir="sessionWithoutCookie" target="all"/>  
         <ant dir="createSessionInServletRequestListener" target="all"/>  
@@ -347,6 +393,10 @@
         <ant dir="servlet-3.1/servletContextGetVirtualServerName" target="all"/>
         <ant dir="localeEncodingMapping" target="all"/>
         <ant dir="servlet-4.0/setSessionTimeout" target="all"/>
+        <antcall target="finish-report"/>
+    </target>
+
+       <target name="servlet-13" depends="init-report">  
         <ant dir="servlet-4.0/addJspFile" target="all"/>
         <ant dir="servlet-4.0/defaultContextPath" target="all"/>
         <ant dir="servlet-4.0/defaultContextPathEar" target="all"/>
@@ -364,7 +414,7 @@
         <antcall target="finish-report"/>
     </target>
 
-    <target name="web-container" depends="init-report">
+    <target name="web-container-1" depends="init-report">
         <ant dir="accessLoggingDynamicReconfig" target="all"/>
         <ant dir="accessLoggingWriteIntervalSeconds" target="all"/>
         <ant dir="accessLoggingBadRequests" target="all"/>
@@ -379,8 +429,12 @@
         <ant dir="commonsLogging" target="all"/>
         <ant dir="commonsLoggingLocalAndGlobal" target="all"/>
         <ant dir="contextPathXmlConfig" target="all"/>
-        <ant dir="contextRoot" target="all"/>
-        <ant dir="contextValveSetRequestedSessionCookiePath" target="all"/>
+        <ant dir="contextRoot" target="all"/> 
+        <antcall target="finish-report"/>
+    </target>
+
+     <target name="web-container-2" depends="init-report">
+     <ant dir="contextValveSetRequestedSessionCookiePath" target="all"/>
         <ant dir="contextXmlConfig" target="all"/> 
         <ant dir="contextXmlLifecycleListener" target="all"/>
         <ant dir="contextXmlLifecycleListenerGlobal" target="all"/>
@@ -395,7 +449,11 @@
         <ant dir="explodedWar" target="all"/>
         <ant dir="extraClassPathJarUrl" target="all"/>
         <ant dir="extraClassPathRelative" target="all"/>
-        <ant dir="formHintField" target="all"/>
+      <antcall target="finish-report"/>
+    </target>
+       
+       <target name="web-container-3" depends="init-report">
+       <ant dir="formHintField" target="all"/>
         <ant dir="formHintFieldPostWithQueryParam" target="all"/>
         <ant dir="formHintFieldPostWithQueryParamPrecedence" target="all"/>
         <ant dir="formHintFieldPrecedence" target="all"/>
@@ -410,6 +468,10 @@
         <ant dir="log4jLocallyBundled" target="all"/>
         <ant dir="log4jXmlInEarFile" target="all"/>
         <ant dir="mimeMappingCaseInsensitiveMatch" target="all"/>
+       <antcall target="finish-report"/>
+    </target>
+
+      <target name="web-container-4" depends="init-report">
         <ant dir="monitorHttpService" target="all"/>
         <ant dir="monitorServletInstance" target="all"/>
         <ant dir="monitorWebRequest" target="all"/>
@@ -425,7 +487,11 @@
         <ant dir="serverRedirectWithQueryString" target="all"/>
         <ant dir="servletRequestLongUri" target="all"/>
         <ant dir="sessionIdCustomGenerator" target="all"/>
-        <ant dir="sessionInvalidateNoCookieInResponse" target="all"/>
+        <antcall target="finish-report"/>
+    </target>
+     
+    <target name="web-container-5" depends="init-report">
+    <ant dir="sessionInvalidateNoCookieInResponse" target="all"/>
         <ant dir="sessionJvmRoute" target="all"/>
         <ant dir="sessionMemoryPersist" target="all"/>
         <ant dir="sessionMemoryPersistPrimitiveClass" target="all"/>
@@ -440,7 +506,11 @@
         <ant dir="ssiEscapeCharacter" target="all"/>
         <ant dir="ssiHtmlEntity" target="all"/>
         <ant dir="threadPoolIdleTimeout" target="all"/>
-        <ant dir="useBundledJsf" target="all"/>
+      <antcall target="finish-report"/>
+    </target>
+    
+   <target name="web-container-6" depends="init-report">
+    <ant dir="useBundledJsf" target="all"/>
         <ant dir="useBundledJsfWithTagCompilation" target="all"/>
         <ant dir="valveGlassFishStyleBackwardCompatible" target="all"/>
         <ant dir="valveTomcatStyle" target="all"/>
@@ -455,7 +525,11 @@
         <ant dir="virtualServerDefaultWebModuleFormLoginJSecurityCheckDirectAccess" target="all"/>
         <ant dir="virtualServerDefaultWebModuleReconfig" target="all"/>
         <ant dir="virtualServerDefaultWebModuleRequestDispatcher" target="all"/>
-        <ant dir="virtualServerDefaultWebModuleRequestPath" target="all"/>
+    <antcall target="finish-report"/>
+    </target>
+
+    <target name="web-container-7" depends="init-report">
+    <ant dir="virtualServerDefaultWebModuleRequestPath" target="all"/>
         <ant dir="virtualServerDocrootDynamicReconfig" target="all"/>
         <ant dir="virtualServerEarWrappedDefaultWebModuleRestart" target="all"/>
         <ant dir="virtualServerLogFile" target="all"/>
@@ -470,7 +544,11 @@
         <ant dir="virtualServerWithCustomValves" target="all"/>
         <ant dir="virtualServerWithCustomErrorReportValve" target="all"/>
         <ant dir="webappAlternateDocroot" target="all"/>
-        <ant dir="webappAlternateDocrootTagFile" target="all"/>
+      <antcall target="finish-report"/>
+    </target>
+
+     <target name="web-container-8" depends="init-report">      
+     <ant dir="webappAlternateDocrootTagFile" target="all"/>
         <ant dir="webappDeployDashDashLibraries" target="all"/>
         <ant dir="webappLoaderConsiderHiddenJarFiles" target="all"/>
         <ant dir="webappLoaderEmptyJar" target="all"/>
@@ -486,7 +564,7 @@
         <ant dir="jsessionIdParameter" target="all"/>
         <ant dir="setWebContextParam" target="all"/>
         <ant dir="contextRootDuplicate" target="all"/>
-        <antcall target="finish-report"/>
+      <antcall target="finish-report"/>
     </target>
 
     <target name="security" depends="init-report">

--- a/appserver/tests/appserv-tests/devtests/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/build.xml
@@ -146,7 +146,7 @@
         <ant dir="welcomePageSecurityConstraintJspExtension" target="all"/>
     </target>
 
-    <target name="taglib" depends="init-report">
+    <target name="taglib" depends="init-report,finish-report">
         <ant dir="jstlHtmlParamOutsideFmtMessage" target="all"/>
         <ant dir="jstlLocaleSupportAPI" target="all"/>
         <ant dir="tagPluginForEach" target="all"/>

--- a/appserver/tests/appserv-tests/devtests/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/build.xml
@@ -144,6 +144,7 @@
         <ant dir="jspconfig" target="all"/>
         <ant dir="welcomePageSecurityConstraintExactMatch" target="all"/>
         <ant dir="welcomePageSecurityConstraintJspExtension" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="taglib" depends="init-report">
@@ -162,6 +163,7 @@
         <ant dir="elFunctionWithoutParams" target="all"/>
         <ant dir="elUninterpretedTag" target="all"/>
         <ant dir="elequals" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="servlet" depends="init-report">
@@ -359,6 +361,7 @@
         <ant dir="servlet-4.0/compositeTrailerSupplier" target="all"/>
         <ant dir="servlet-4.0/pushArbitraryMethod" target="all"/>
         <ant dir="servlet-4.0/pushDynamic" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="web-container" depends="init-report">
@@ -483,6 +486,7 @@
         <ant dir="jsessionIdParameter" target="all"/>
         <ant dir="setWebContextParam" target="all"/>
         <ant dir="contextRootDuplicate" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="security" depends="init-report">
@@ -524,6 +528,7 @@
         <ant dir="servlet-3.1/changeSessionId" target="all"/>
         <ant dir="servlet-3.1/denyUncoveredHttpMethods" target="all"/>
         <ant dir="servlet-3.1/anyAuthenticatedUser" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="http-connector" depends="init-report">
@@ -568,14 +573,17 @@
         <ant dir="v3HttpListenerDynamicConfig" target="all"/>
         <ant dir="wrongTransport" target="all"/>
         <ant dir="trailerHeader" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="comet" depends="init-report">
         <ant dir="cometEcho" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="misc" depends="init-report">
         <ant dir="genDocSchema" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="weblogicDD" depends="init-report">
@@ -598,10 +606,12 @@
         <ant dir="networkListenerTarget" target="all"/>
         <ant dir="portUnificationTarget" target="all"/>
         <ant dir="wrongTransportTarget" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="ha" depends="init-report">
         <ant dir="ha/ssoFailover" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="init-report" unless="report.inited">

--- a/appserver/tests/appserv-tests/devtests/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/build.xml
@@ -710,7 +710,7 @@
         <echo message="#################################################"/>
     </target>
 
-    <target name="all" depends="init,init-report,comet,el,http-connector,jsp,security,servlet,taglib,web-container,weblogicDD,clustering,ha,misc,finish-report"/>
+    <target name="all" depends="init,init-report,comet,el,http-connector,jsp,security,taglib,weblogicDD,clustering,ha,misc,finish-report"/>
     <target name="embedded-all" depends="embedded-setup,all"/>
 
     <target name="embedded-setup">

--- a/appserver/tests/appserv-tests/devtests/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/build.xml
@@ -146,13 +146,14 @@
         <ant dir="welcomePageSecurityConstraintJspExtension" target="all"/>
     </target>
 
-    <target name="taglib" depends="init-report,finish-report">
+    <target name="taglib" depends="init-report">
         <ant dir="jstlHtmlParamOutsideFmtMessage" target="all"/>
         <ant dir="jstlLocaleSupportAPI" target="all"/>
         <ant dir="tagPluginForEach" target="all"/>
         <ant dir="tagPluginForEachTagFile" target="all"/>
         <ant dir="tagfileInclude" target="all"/>
         <ant dir="tagplugin" target="all"/>
+        <antcall target="finish-report"/>
     </target>
 
     <target name="el" depends="init-report">

--- a/appserver/tests/appserv-tests/devtests/web/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/web/run_test.sh
@@ -276,6 +276,18 @@ run_test_id(){
 
 list_test_ids(){
     echo web_all
+    echo jsp 
+    echo taglib 
+    echo el 
+    echo servlet 
+    echo web-container 
+    echo security 
+    echo http-connector 
+    echo comet 
+    echo misc 
+    echo clustering 
+    echo ha 
+    echo embedded-all
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/web/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/web/run_test.sh
@@ -124,6 +124,9 @@ get_test_target(){
 		web_all )
 			TARGET=all
 			export TARGET;;
+                * )
+                  TARGET=$1
+                  export TARGET;;
 	esac
 
 }

--- a/appserver/tests/appserv-tests/devtests/web/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/web/run_test.sh
@@ -279,8 +279,27 @@ list_test_ids(){
     echo jsp 
     echo taglib 
     echo el 
-    echo servlet 
-    echo web-container 
+    echo servlet-1
+    echo servlet-2
+    echo servlet-3
+    echo servlet-4
+    echo servlet-5
+    echo servlet-6
+    echo servlet-7
+    echo servlet-8
+    echo servlet-9
+    echo servlet-10
+    echo servlet-11
+    echo servlet-12
+    echo servlet-13 
+    echo web-container-1
+    echo web-container-2
+    echo web-container-3
+    echo web-container-4
+    echo web-container-5 
+    echo web-container-6
+    echo web-container-7
+    echo web-container-8 
     echo security 
     echo http-connector 
     echo comet 

--- a/appserver/tests/findbug/run_test.sh
+++ b/appserver/tests/findbug/run_test.sh
@@ -53,6 +53,12 @@ findbugs_run(){
 	# Run findbugs on open source ws.
 	echo "Running findbugs on ws"
 	cd $WORKSPACE/main
+  
+      if [ -n "$TARGET_DIR" ]; then
+        echo "Running findbugs in $TARGET_DIR"
+        cd $TARGET_DIR
+      fi
+
 	mvn -e -s $MAVEN_SETTINGS -Dmaven.repo.local=$WORKSPACE/repository -Pfindbugs clean install
 	mvn -e -s $MAVEN_SETTINGS -Dmaven.repo.local=$WORKSPACE/repository -Pfindbugs findbugs:findbugs
 

--- a/appserver/tests/findbug/run_test.sh
+++ b/appserver/tests/findbug/run_test.sh
@@ -72,6 +72,10 @@ findbugs_low_priority_all_run(){
   # Run findbugs on open source ws.
   echo "Running findbugs on ws"
   cd $WORKSPACE/main
+  if [ -n "$TARGET_DIR" ]; then
+      echo "Running findbugs in $TARGET_DIR"
+      cd $TARGET_DIR
+  fi
   mvn -e -s $MAVEN_SETTINGS -Dmaven.repo.local=$WORKSPACE/repository -Pfindbugs clean install
   mvn -e -s $MAVEN_SETTINGS -Dmaven.repo.local=$WORKSPACE/repository -B -Pfindbugs -Dfindbugs.threshold=Low findbugs:findbugs
 
@@ -83,7 +87,14 @@ generate_findbugs_result(){
 
 	# check findbbugs
 	set +e
-	cd /net/gf-hudson/scratch/gf-hudson/export2/hudson/tools/findbugs-tool-latest; ./findbugscheck $WORKSPACE/main
+        if [ -n "$TARGET_DIR" ]; then
+           export RESULT_DIR=$WORKSPACE/main/$TARGET_DIR
+           echo "Generating findbugs result in $RESULT_DIR"
+        else
+           export RESULT_DIR=$WORKSPACE/main
+           echo "Generating findbugs result in $RESULT_DIR"
+        fi
+	cd /net/gf-hudson/scratch/gf-hudson/export2/hudson/tools/findbugs-tool-latest; ./findbugscheck $RESULT_DIR
 	if [ $? -ne 0 ]
 	then
 	   echo "FAILED" > $WORKSPACE/results/findbugs_results/findbugscheck.log
@@ -92,7 +103,7 @@ generate_findbugs_result(){
 	fi
 	set -e
 	# archive the findbugs results
-	for i in `find $WORKSPACE/main -name findbugsXml.xml`
+	for i in `find $RESULT_DIR -name findbugsXml.xml`
 	do
 	   cp $i $WORKSPACE/results/findbugs_results/`echo $i | sed s@"$WORKSPACE"@@g | sed s@"/"@"_"@g`
 	done
@@ -133,6 +144,14 @@ run_test_id(){
     findbugs_low_priority_all)
       findbugs_low_priority_all_run
       generate_findbugs_low_priority_all_result;;
+    findbugs_appserver )
+      export TARGET_DIR=appserver
+       findbugs_run
+       generate_findbugs_result;;
+    findbugs_nucleus )
+      export TARGET_DIR=nucleus
+       findbugs_run
+       generate_findbugs_result;;
   esac
   upload_test_results
   delete_bundle
@@ -140,8 +159,10 @@ run_test_id(){
 
 
 list_test_ids(){
-	echo findbugs_all
-  echo findbugs_low_priority_all
+       echo findbugs_all
+       echo findbugs_low_priority_all
+       echo findbugs_appserver
+       echo findbugs_nucleus
 }
 
 OPT=$1


### PR DESCRIPTION
The tests under admi cli project have been split into five groups in order to reduce the run time.