### PR TITLE
Tests have been split into five test ids to reduce execution time

### DIFF
--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -146,7 +146,72 @@
                         logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
                         restart-domain, config-modularity, teardown"/>
 
-    <target name="cluster" depends="init">
+   <!-- modification for splitting test -->
+      
+    <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance,teardown"/>
+     <target name="cli-group-2" depends="setup,cluster,configs, sync, domain,teardown"/>
+    <target name="cli-group-3" depends="setup,backup, tokens, validation, node,teardown"/>
+   <target name="cli-group-4" depends="setup,logging-command,load-balancer, getset, misc-commands, teardown"/>
+    <target name="cli-group-5" depends="setup,all-jms, manual-sync, upgrade,
+                        restart-domain, config-modularity, teardown"/>
+
+
+     <target name="admin-cli-group-1" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-1"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+    <target name="admin-cli-group-2" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-2"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+   <target name="admin-cli-group-3" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-3"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+  <target name="admin-cli-group-4" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-4"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+ <target name="admin-cli-group-5" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-5"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+
+   <!-- modification for splitting test -->
+   
+   
+
+   <target name="cluster" depends="init">
         <runtest classname="admin.ClusterTest"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -146,6 +146,67 @@
                         logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
                         restart-domain, config-modularity, teardown"/>
 
+
+     <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance,teardown"/>
+     <target name="cli-group-2" depends="setup,cluster,configs, sync, domain,teardown"/>
+     <target name="cli-group-3" depends="setup,backup, tokens, validation, node,teardown"/>
+     <target name="cli-group-4" depends="setup,logging-command,load-balancer, getset, misc-commands, teardown"/>
+     <target name="cli-group-5" depends="setup,all-jms, manual-sync, upgrade,
+                        restart-domain, config-modularity, teardown"/>
+
+
+     <target name="admin-cli-group-1" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-1"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+    <target name="admin-cli-group-2" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-2"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+   <target name="admin-cli-group-3" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-3"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+    <target name="admin-cli-group-4" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-4"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+   <target name="admin-cli-group-5" depends="clean,init">
+        <record name="admin.output" action="start" />
+        <antcall target="prerun"/>
+        <antcall target="cli-group-5"/>
+        <record name="admin.output" action="stop" />
+        <antcall target="stacker"/>
+        <antcall target="dev-report"/>
+        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
+    </target>
+
+
+
     <target name="cluster" depends="init">
         <runtest classname="admin.ClusterTest"/>
     </target>

--- a/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/build.xml
@@ -146,72 +146,7 @@
                         logging-command,load-balancer, getset, misc-commands, all-jms, manual-sync, upgrade,
                         restart-domain, config-modularity, teardown"/>
 
-   <!-- modification for splitting test -->
-      
-    <target name="cli-group-1" depends="setup, monitoring, zombie, ports, instance,teardown"/>
-     <target name="cli-group-2" depends="setup,cluster,configs, sync, domain,teardown"/>
-    <target name="cli-group-3" depends="setup,backup, tokens, validation, node,teardown"/>
-   <target name="cli-group-4" depends="setup,logging-command,load-balancer, getset, misc-commands, teardown"/>
-    <target name="cli-group-5" depends="setup,all-jms, manual-sync, upgrade,
-                        restart-domain, config-modularity, teardown"/>
-
-
-     <target name="admin-cli-group-1" depends="clean,init">
-        <record name="admin.output" action="start" />
-        <antcall target="prerun"/>
-        <antcall target="cli-group-1"/>
-        <record name="admin.output" action="stop" />
-        <antcall target="stacker"/>
-        <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
-    </target>
-
-    <target name="admin-cli-group-2" depends="clean,init">
-        <record name="admin.output" action="start" />
-        <antcall target="prerun"/>
-        <antcall target="cli-group-2"/>
-        <record name="admin.output" action="stop" />
-        <antcall target="stacker"/>
-        <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
-    </target>
-
-   <target name="admin-cli-group-3" depends="clean,init">
-        <record name="admin.output" action="start" />
-        <antcall target="prerun"/>
-        <antcall target="cli-group-3"/>
-        <record name="admin.output" action="stop" />
-        <antcall target="stacker"/>
-        <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
-    </target>
-
-  <target name="admin-cli-group-4" depends="clean,init">
-        <record name="admin.output" action="start" />
-        <antcall target="prerun"/>
-        <antcall target="cli-group-4"/>
-        <record name="admin.output" action="stop" />
-        <antcall target="stacker"/>
-        <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
-    </target>
-
- <target name="admin-cli-group-5" depends="clean,init">
-        <record name="admin.output" action="start" />
-        <antcall target="prerun"/>
-        <antcall target="cli-group-5"/>
-        <record name="admin.output" action="stop" />
-        <antcall target="stacker"/>
-        <antcall target="dev-report"/>
-        <echo message="Detailed results available under ${env.APS_HOME}/test_results.html"/>
-    </target>
-
-
-   <!-- modification for splitting test -->
-   
-   
-
-   <target name="cluster" depends="init">
+    <target name="cluster" depends="init">
         <runtest classname="admin.ClusterTest"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -81,12 +81,15 @@ get_test_target(){
 		admin_cli_all )
 			TARGET=all
 			export TARGET;;
+                * )
+                       TARGET=$1
+                       export TARGET;;
 	esac
 
 }
 
 list_test_ids(){
-	echo admin_cli_all
+	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin-cli-group-4 admin-cli-group-5
 }
 
 OPT=$1

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -67,9 +67,6 @@ run_test_id(){
 	check_successful_run
     generate_junit_report $1
     change_junit_report_class_names
-}
-
-post_test_run(){
     copy_test_artifects
     upload_test_results
     delete_bundle
@@ -81,12 +78,15 @@ get_test_target(){
 		admin_cli_all )
 			TARGET=all
 			export TARGET;;
-	esac
+	        * )
+                       TARGET=$1
+                       export TARGET;;
+        esac
 
 }
 
 list_test_ids(){
-	echo admin_cli_all
+	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin-cli-group-4 admin-cli-group-5
 }
 
 OPT=$1
@@ -96,6 +96,5 @@ case $OPT in
 	list_test_ids )
 		list_test_ids;;
 	run_test_id )
-		trap post_test_run EXIT
 		run_test_id $TEST_ID ;;
 esac

--- a/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/run_test.sh
@@ -67,6 +67,9 @@ run_test_id(){
 	check_successful_run
     generate_junit_report $1
     change_junit_report_class_names
+}
+
+post_test_run(){
     copy_test_artifects
     upload_test_results
     delete_bundle
@@ -78,15 +81,12 @@ get_test_target(){
 		admin_cli_all )
 			TARGET=all
 			export TARGET;;
-	        * )
-                       TARGET=$1
-                       export TARGET;;
-        esac
+	esac
 
 }
 
 list_test_ids(){
-	echo admin_cli_all admin-cli-group-1 admin-cli-group-2 admin-cli-group-3 admin-cli-group-4 admin-cli-group-5
+	echo admin_cli_all
 }
 
 OPT=$1
@@ -96,5 +96,6 @@ case $OPT in
 	list_test_ids )
 		list_test_ids;;
 	run_test_id )
+		trap post_test_run EXIT
 		run_test_id $TEST_ID ;;
 esac


### PR DESCRIPTION
Tests have been split into five test ids to reduce execution time while running in parallel