### PR TITLE
Fixes #22019. Updating Glassfish Dependencies to the latest version

### DIFF
--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -61,6 +61,6 @@
 	<parameter-encoding default-charset="UTF-8" />
  </locale-charset-info>
 
-<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.10.jar:WEB-INF/extra/commons-fileupload-1.3.2.jar:WEB-INF/extra/commons-io-1.3.1.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
+<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.4.0.1.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.4.0.1.jar:WEB-INF/extra/commons-fileupload-1.3.2.jar:WEB-INF/extra/commons-io-1.3.1.jar:WEB-INF/extra/json-2.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
 
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -67,7 +67,7 @@
         <jstl-api.version>1.2.1</jstl-api.version>
         <mojarra.version>2.3.2</mojarra.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>4.0.2.10</woodstock.version>
+        <woodstock.version>4.4.0.1</woodstock.version>
         <javax.ejb-api.version>3.2</javax.ejb-api.version>
         <javax.interceptor-api.version>1.2</javax.interceptor-api.version>
         <javax.xml.rpc-api.version>1.1.1</javax.xml.rpc-api.version>
@@ -787,7 +787,7 @@
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>
                 <artifactId>json</artifactId>
-                <version>1.0</version>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>


### PR DESCRIPTION
Fixes #22019 