### PR TITLE
Enabling security WSS tests

### DIFF
--- a/appserver/tests/appserv-tests/devtests/security/resultCount.sh
+++ b/appserver/tests/appserv-tests/devtests/security/resultCount.sh
@@ -43,7 +43,7 @@
 
 FILES="$APS_HOME/test_resultsValid.xml $APS_HOME/security-gtest-results.xml"
 
-TOTAL=797
+TOTAL=800
 PASSED=0
 FAILED=0
 for i in $FILES

--- a/appserver/tests/appserv-tests/devtests/security/wss/encThenSign-default-conf/servletws/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/wss/encThenSign-default-conf/servletws/build.xml
@@ -55,11 +55,8 @@
     &testproperties;
     &commonSecurity;
 
-    <!--<target name="all" 
-    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>-->
-    <target name="all" depends="clean">
-      <echo message="FIXME: Known failure."/>
-    </target>
+    <target name="all" 
+    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>
      
     <target name="run-test" 
     depends="clean, build, deploy, run, undeploy"/>

--- a/appserver/tests/appserv-tests/devtests/security/wss/permethod/servletws/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/wss/permethod/servletws/build.xml
@@ -55,11 +55,8 @@
     &testproperties;
     &commonSecurity;
 
-    <!--<target name="all" 
-    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>-->
-    <target name="all" depends="clean">
-      <echo message="FIXME: Known failure."/>
-    </target>
+    <target name="all" 
+    depends="clean, build, setup, deploy, run, undeploy, unsetup"/>
 
     <target name="run-test" 
     depends="clean, build, deploy, run, undeploy"/>

--- a/appserver/tests/test_groups/gating
+++ b/appserver/tests/test_groups/gating
@@ -19,4 +19,5 @@ servlet_tck_all
 findbugs_all
 embedded_publisher_all
 copyright
-connector_all
+jdbc_all
+jms_all


### PR DESCRIPTION
2 security tests were commented previously due to wscompile failing to run. This was due to missing JAVA_HOME setting which is a must for wscompile . This PR re-enables the tests since JAVA_HOME setting has been fixed.