### PR TITLE
Fixes #21532 : com.sun.jts.CosTransactions.GlobalTID breaks the equals/hashCode contract

### DIFF
--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/GlobalTID.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/GlobalTID.java
@@ -67,13 +67,11 @@ package com.sun.jts.CosTransactions;
 import java.io.*;
 
 import org.omg.CosTransactions.*;
-import com.sun.jts.trace.*;
 
 
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import com.sun.logging.LogDomains;
-import com.sun.jts.utils.LogFormatter;
 
 /**This class provides a wrapper for the otid_t class in the
  * org.omg.CosTSInteroperation package to allow us to add operations.
@@ -310,13 +308,15 @@ public class GlobalTID extends Object {
 
         // Add up the values in the XID.
 
-        if( realTID.tid != null )
-            for( int pos = 0; pos < realTID.tid.length; pos++ )
+        if( realTID.tid != null ) {
+            for (int pos = 0; pos < realTID.tid.length - realTID.bqual_length; pos++) {
                 hashCode += realTID.tid[pos];
+            }
+        }
 
-        // Add in the formatId and branch qualifier length.
+        // Add in the formatId.
 
-        hashCode += realTID.formatID + realTID.bqual_length;
+        hashCode += realTID.formatID;
 
         // Multiply the result by the "magic hashing constant".
 


### PR DESCRIPTION
Fixes #21532 : Removing branch qualifier values from calculation of hashcode.