### PR TITLE
Jersey 2.26-b08 + Jackson.jaxrs modules repackaging.

### DIFF
--- a/nucleus/admin/util/pom.xml
+++ b/nucleus/admin/util/pom.xml
@@ -177,8 +177,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/packager/nucleus-jersey/pom.xml
+++ b/nucleus/packager/nucleus-jersey/pom.xml
@@ -115,10 +115,6 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
@@ -131,8 +127,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -144,7 +144,7 @@
         <pfl.version>4.0.0-b004</pfl.version>
         <gmbal.version>4.0.0-b001</gmbal.version>
         <antlr.version>2.7.6</antlr.version>
-        <jersey.version>2.26-b07</jersey.version>
+        <jersey.version>2.26-b08</jersey.version>
         <jackson.version>2.8.4</jackson.version>
         <jettison.version>1.3.3</jettison.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
@@ -812,11 +812,6 @@
                 <version>${javax.el.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-base</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
@@ -832,8 +827,8 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
The main reason for this Jersey release is that jackson depends on JAX-RS 2.0 and defines OSGi dependency as [2.0, 2.1). That effectively blocks JAX-RS 2.1 integration.

Jackson maintainer is aware of this issue, but release which will fixed won't be available soon enough. See https://github.com/FasterXML/jackson-jaxrs-providers/pull/98 for more details.