### PR TITLE
Issue_22036: Upgrading bean-validation to Candidate Release 3

### DIFF
--- a/appserver/tests/quicklook/bean-validator/simple-bv-servlet/simple-bv-servlet.policy
+++ b/appserver/tests/quicklook/bean-validator/simple-bv-servlet/simple-bv-servlet.policy
@@ -40,5 +40,4 @@
 
 grant codeBase "file:${com.sun.aas.instanceRoot}/applications/simple-bv-servlet/-" {
       permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-      permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
 };

--- a/appserver/tests/quicklook/bean-validator/simple-bv-servlet/simple-bv-servlet.policy
+++ b/appserver/tests/quicklook/bean-validator/simple-bv-servlet/simple-bv-servlet.policy
@@ -40,4 +40,5 @@
 
 grant codeBase "file:${com.sun.aas.instanceRoot}/applications/simple-bv-servlet/-" {
       permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+      permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
 };

--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -142,4 +142,5 @@ grant {
 
 grant  codeBase "file:${com.sun.aas.instanceRoot}/applications/-"{
     permission java.io.FilePermission       "<<ALL FILES>>", "read,write";
+    permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
 };

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -132,9 +132,9 @@
         <grizzly.version>2.4.0-beta8</grizzly.version>
         <grizzly.npn.version>1.7</grizzly.npn.version>
         <jboss.logging.annotation.version>2.0.1.Final</jboss.logging.annotation.version>
-        <javax.validation.version>2.0.0.CR2</javax.validation.version>
+        <javax.validation.version>2.0.0.CR3</javax.validation.version>
         <javax.validation.version.lowerbound>1.1.0.Final</javax.validation.version.lowerbound>
-        <hibernate-validator.version>6.0.0.CR2</hibernate-validator.version>
+        <hibernate-validator.version>6.0.0.CR3</hibernate-validator.version>
         <hibernate-validator.version.lowerbound>5.2.4.Final</hibernate-validator.version.lowerbound>
         <fasterxml.classmate.version>1.3.1</fasterxml.classmate.version>
         <javassist.version>3.22.0-CR2</javassist.version>
@@ -145,7 +145,6 @@
         <hk2.plugin.version>2.5.0-b42</hk2.plugin.version>
         <jboss.logging.version>3.3.1.Final</jboss.logging.version>
         <fasterxml.classmate.version>1.3.3</fasterxml.classmate.version>
-        <javassist.version>3.22.0-CR2</javassist.version>
         <trilead-ssh2.version>build212-hudson-6</trilead-ssh2.version>
         <pfl.version>4.0.0-b004</pfl.version>
         <gmbal.version>4.0.0-b001</gmbal.version>


### PR DESCRIPTION
Refer issue #[22036](https://github.com/javaee/glassfish/issues/22036) for details.
Fixes #22036 