### PR TITLE
Fixes #21586 : GlassFish Requires its own cacerts file or won't start and displays misleading message

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -62,6 +62,7 @@ import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.HostAndPort;
 import com.sun.enterprise.util.io.ServerDirs;
 import java.util.logging.Level;
+import com.sun.enterprise.util.SystemPropertyConstants;
 
 /**
  * A class that's supposed to capture all the behavior common to operation
@@ -522,8 +523,13 @@ public abstract class LocalServerCommand extends CLICommand {
             return null;
 
         File mp = new File(new File(serverDirs.getServerDir(), "config"), "cacerts.jks");
-        if (!mp.canRead())
-            return null;
+        if (!mp.canRead()){
+            String javaHome= System.getProperty(SystemPropertyConstants.JAVA_ROOT_PROPERTY);
+            mp = new File(javaHome, "/jre/lib/security/cacerts");
+            if (!mp.canRead())
+                return null;
+            return mp;
+        }
         return mp;
     }
 


### PR DESCRIPTION
Fixes #21586 : 
The bug was if there is no cacerts.jks file at the default location($S1AS_HOME/domains/domain1/config) then the start-domain command fails.

Suggested Fix:
Modified code to allow the use of java provided cacerts file to verify master password if there is no glassfish specific cacerts file.