### PR TITLE
Fixes #21018 : set-batch-runtime-configuration page in console is fixed.

### DIFF
--- a/appserver/admingui/full/src/main/resources/batch/batchConfiguration_1.inc
+++ b/appserver/admingui/full/src/main/resources/batch/batchConfiguration_1.inc
@@ -55,7 +55,7 @@
         setSessionAttribute(key="#{pageSession.tabSetName}" value="batchConfig");
         createMap(result="#{pageSession.attrsMap}")
         mapPut(map="#{pageSession.attrsMap}" key="target" value="#{pageSession.encodedTarget}");
-        gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-batch-runtime-configuration"  method="GET" result="#{requestScope.resp}");
+        gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-batch-runtime-configuration?target=#{pageSession.encodedTarget}"  method="GET" result="#{requestScope.resp}");
         setPageSessionAttribute(key="valueMap", value="#{requestScope.resp.data.extraProperties.listBatchRuntimeConfiguration}");
         mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.encodedTarget}");
     />


### PR DESCRIPTION
#21018 : Added missing target name to make  batch runtime configuration page work.