### PR TITLE
Integ:  commons-io 2.5

### DIFF
--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -61,6 +61,6 @@
 	<parameter-encoding default-charset="UTF-8" />
  </locale-charset-info>
 
-<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.10.jar:WEB-INF/extra/commons-fileupload-1.3.2.jar:WEB-INF/extra/commons-io-1.3.1.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
+<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.10.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.10.jar:WEB-INF/extra/commons-fileupload-1.3.2.jar:WEB-INF/extra/commons-io-2.5.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
 
 </sun-web-app>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -965,7 +965,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.3.1</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>


### PR DESCRIPTION

Fixes #22019 : Updating Glassfish Dependencies to the latest version

Updated :
commons-io - 1.3.1(previous), 2.5(latest)