### PR TITLE
bug 26498905: ensure class initialized before using unsafe

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -122,7 +122,7 @@
         <findbugs.version>3.0.3</findbugs.version>
         <findbugs.glassfish.logging.validLoggerPrefixes>javax.enterprise</findbugs.glassfish.logging.validLoggerPrefixes>
 
-        <glassfish-corba.version>4.1.0</glassfish-corba.version>
+        <glassfish-corba.version>4.1.1-b001</glassfish-corba.version>
         <stax-api.version>1.0-2</stax-api.version>
         <slf4j.version>1.7.21</slf4j.version>
         <javax.validation.osgi.version>2.0.0</javax.validation.osgi.version>


### PR DESCRIPTION
This pulls in glassfish-corba 4.1.1-b001, which fixes bug 26498905