### PR TITLE
#22115 :  Resolve the hostname in admin GUI dev tests

### DIFF
--- a/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/SeleniumHelper.java
+++ b/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/SeleniumHelper.java
@@ -122,6 +122,7 @@ public class SeleniumHelper {
               hostName = InetAddress.getLocalHost().getCanonicalHostName();
             }
         } catch (UnknownHostException ex) {
+            hostName = "localhost";
             Logger.getLogger(SeleniumHelper.class.getName()).log(Level.SEVERE, null, ex);
         }
         return "http://" + hostName + ":" + getParameter("admin.port", "4848");

--- a/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/SeleniumHelper.java
+++ b/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/util/SeleniumHelper.java
@@ -116,9 +116,11 @@ public class SeleniumHelper {
     }
 
     public String getBaseUrl() {
-        String hostName = null;
+        String hostName = SeleniumHelper.getParameter("host", null);
         try {
-            hostName = InetAddress.getLocalHost().getCanonicalHostName();
+            if (hostName == null) {
+              hostName = InetAddress.getLocalHost().getCanonicalHostName();
+            }
         } catch (UnknownHostException ex) {
             Logger.getLogger(SeleniumHelper.class.getName()).log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
Accepting host as a parameter. so that user can send any host name to run their dev tests.