### PR TITLE
Fix #21365: Include additional check while detecting archive type

### DIFF
--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -41,6 +41,7 @@
 package com.sun.enterprise.security.ee;
 
 import com.sun.enterprise.security.SecurityLifecycle;
+import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.common.DeploymentUtils;
@@ -83,6 +84,12 @@ public class SecuritySniffer extends GenericSniffer {
         super("security", null, null);
     }
 
+    public boolean handles(DeploymentContext context) {
+        ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
+        if (archiveType != null && !supportsArchiveType(archiveType)) return false;
+        return archiveType.equals(DOLUtils.warType()) || archiveType.equals(DOLUtils.earType()) || archiveType.equals(DOLUtils.ejbType()) || handles(context.getSource());
+    }
+
     /**
      * Returns true if the passed file or directory is recognized by this
      * instance.
@@ -91,10 +98,7 @@ public class SecuritySniffer extends GenericSniffer {
      * @return true if this sniffer handles this application type
      */
     public boolean handles(ReadableArchive location) {
-        ArchiveType archiveType = location.getExtraData(ArchiveType.class);
-        boolean rv = archiveType.equals(DOLUtils.warType()) || archiveType.equals(DOLUtils.earType()) || archiveType.equals(DOLUtils.ejbType());
-
-        return (rv || DeploymentUtils.isArchiveOfType(location, DOLUtils.warType(), habitat) || DeploymentUtils.isArchiveOfType(location, DOLUtils.earType(), habitat) || isJar(location));
+        return (DeploymentUtils.isArchiveOfType(location, DOLUtils.warType(), habitat) || DeploymentUtils.isArchiveOfType(location, DOLUtils.earType(), habitat) || isJar(location));
     }
 
     /**

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -80,11 +80,10 @@ public class SecuritySniffer extends GenericSniffer {
     };
 
     public SecuritySniffer() {
-        super("security", "WEB-INF/web.xml", null);
-        
+        super("security", null, null);
     }
-    
-   /**
+
+    /**
      * Returns true if the passed file or directory is recognized by this
      * instance.
      *
@@ -92,7 +91,10 @@ public class SecuritySniffer extends GenericSniffer {
      * @return true if this sniffer handles this application type
      */
     public boolean handles(ReadableArchive location) {
-        return (DeploymentUtils.isArchiveOfType(location, DOLUtils.warType(), habitat) || DeploymentUtils.isArchiveOfType(location, DOLUtils.earType(), habitat) || isJar(location));
+        ArchiveType archiveType = location.getExtraData(ArchiveType.class);
+        boolean rv = archiveType.equals(DOLUtils.warType()) || archiveType.equals(DOLUtils.earType()) || archiveType.equals(DOLUtils.ejbType());
+
+        return (rv || DeploymentUtils.isArchiveOfType(location, DOLUtils.warType(), habitat) || DeploymentUtils.isArchiveOfType(location, DOLUtils.earType(), habitat) || isJar(location));
     }
 
     /**

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -81,7 +81,7 @@ public class SecuritySniffer extends GenericSniffer {
     };
 
     public SecuritySniffer() {
-        super("security", null, null);
+        super("security", "WEB-INF/web.xml", null);
     }
 
     /**
@@ -91,6 +91,7 @@ public class SecuritySniffer extends GenericSniffer {
      * @param context deployment context
      * @return true if the location is recognized by this sniffer
      */
+    @Override
     public boolean handles(DeploymentContext context) {
         ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
         if (archiveType != null && !supportsArchiveType(archiveType)) {
@@ -108,6 +109,7 @@ public class SecuritySniffer extends GenericSniffer {
      * @param location the file or directory to explore
      * @return true if this sniffer handles this application type
      */
+    @Override
     public boolean handles(ReadableArchive location) {
         return (DeploymentUtils.isArchiveOfType(location, DOLUtils.warType(), habitat) || DeploymentUtils.isArchiveOfType(location, DOLUtils.earType(), habitat) || isJar(location));
     }

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -93,8 +93,12 @@ public class SecuritySniffer extends GenericSniffer {
      */
     public boolean handles(DeploymentContext context) {
         ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
-        if (archiveType != null && !supportsArchiveType(archiveType)) return false;
-        return archiveType.equals(DOLUtils.warType()) || archiveType.equals(DOLUtils.earType()) || archiveType.equals(DOLUtils.ejbType()) || handles(context.getSource());
+        if (archiveType != null && !supportsArchiveType(archiveType)) {
+            return false;
+        }
+        if (archiveType != null && (archiveType.equals(DOLUtils.warType()) || archiveType.equals(DOLUtils.earType()) || archiveType.equals(DOLUtils.ejbType())))
+            return true;
+        return handles(context.getSource());
     }
 
     /**

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -84,6 +84,13 @@ public class SecuritySniffer extends GenericSniffer {
         super("security", null, null);
     }
 
+    /**
+     * Returns true if the passed file or directory is recognized by this
+     * sniffer.
+     *
+     * @param context deployment context
+     * @return true if the location is recognized by this sniffer
+     */
     public boolean handles(DeploymentContext context) {
         ArchiveType archiveType = habitat.getService(ArchiveType.class, context.getArchiveHandler().getArchiveType());
         if (archiveType != null && !supportsArchiveType(archiveType)) return false;

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
@@ -102,6 +102,7 @@ public abstract class GenericSniffer implements Sniffer {
         if (archiveType != null && !supportsArchiveType(archiveType)) {
             return false;
         }
+        context.getSource().setExtraData(ArchiveType.class, archiveType);
         return handles(context.getSource());
     }
 

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
@@ -102,7 +102,6 @@ public abstract class GenericSniffer implements Sniffer {
         if (archiveType != null && !supportsArchiveType(archiveType)) {
             return false;
         }
-        context.getSource().setExtraData(ArchiveType.class, archiveType);
         return handles(context.getSource());
     }
 


### PR DESCRIPTION
Fix #21365: Copied the Payara fix.

It looks like the web application had to be such that WarDetector.java(org/glassfish/web/sniffer/WarDetector.java) is unable to detect this is a war. This means that the application not only had missing web.xml but also did not have a WEB-INF folder. Not sure if this is a valid war archive. I did not find anything conclusive in the servlet spec as well

The Payara fix(payara/Payara@0b55074) adds one more condition to check that this indeed is a war. I have added the same in this PR
