### PR TITLE
Fixing Issue #21718: changing logic of implicit bean discovery according to CDI 2.0 spec.

### DIFF
--- a/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
+++ b/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
@@ -170,9 +170,17 @@ public class WeldUtils {
             throws IOException {
         boolean result = false;
 
-        // Archives with extensions are not candidates for implicit bean discovery
+         //refer CDI 2.0 spec section 12.1
+        // Archives with extensions and no beans.xml file are not candidates for implicit bean discovery
         if (!archive.exists(META_INF_SERVICES_EXTENSION)) {
           result = isImplicitBeanArchive(context, archive.getURI());
+        } else {
+        	
+        	if (archive.exists(META_INF_BEANS_XML)) {
+        		
+        		result = isImplicitBeanArchive(context, archive.getURI());
+        	}
+        	
         }
 
         return result;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -471,10 +471,11 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                                                new Object[]{entry});
                                 }
 
-                                if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
-                                    weblibJarsThatAreBeanArchives.add(weblibJarArchive);
-                                }
-                            }
+                              //  if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
+                              //      weblibJarsThatAreBeanArchives.add(weblibJarArchive);
+                              //  }
+					  weblibJarsThatAreBeanArchives.add(weblibJarArchive);                            
+				}
                         } else {
                             // Check for classes annotated with qualified annotations
                             if (WeldUtils.isImplicitBeanArchive(context, weblibJarArchive)) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -471,11 +471,10 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                                                new Object[]{entry});
                                 }
 
-                              //  if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
-                              //      weblibJarsThatAreBeanArchives.add(weblibJarArchive);
-                              //  }
-					  weblibJarsThatAreBeanArchives.add(weblibJarArchive);                            
-				}
+                                if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
+                                    weblibJarsThatAreBeanArchives.add(weblibJarArchive);
+                                }					                            
+			    }
                         } else {
                             // Check for classes annotated with qualified annotations
                             if (WeldUtils.isImplicitBeanArchive(context, weblibJarArchive)) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -470,7 +470,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                                                CDILoggerInfo.WEB_INF_LIB_CONSIDERING_BEAN_ARCHIVE,
                                                new Object[]{entry});
                                 }
-                                
+
                                 if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
                                     weblibJarsThatAreBeanArchives.add(weblibJarArchive);
                                 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -470,11 +470,11 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
                                                CDILoggerInfo.WEB_INF_LIB_CONSIDERING_BEAN_ARCHIVE,
                                                new Object[]{entry});
                                 }
-
+                                
                                 if (!bdMode.equals(BeanDiscoveryMode.ANNOTATED) || isImplicitBeanArchive(context, weblibJarArchive)) {
                                     weblibJarsThatAreBeanArchives.add(weblibJarArchive);
-                                }					                            
-			    }
+                                }
+                            }
                         } else {
                             // Check for classes annotated with qualified annotations
                             if (WeldUtils.isImplicitBeanArchive(context, weblibJarArchive)) {


### PR DESCRIPTION
According to CDI 2.0 spec section 12.1 "Archives with extensions and no beans.xml file are not candidates for implicit bean discovery"

#21718