### PR TITLE
Fixes 22122 : Updated AppClientScanner to scan annotations even for POJOs

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/AppClientScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/AppClientScanner.java
@@ -73,7 +73,6 @@ import java.util.logging.Level;
 @Service(name="car")
 @PerLookup
 public class AppClientScanner extends ModuleScanner<ApplicationClientDescriptor> {
-    private static final Class[] managedBeanAnnotations = new Class[] {javax.annotation.ManagedBean.class}; 
 
     @Override
     public void process(ReadableArchive archive, ApplicationClientDescriptor bundleDesc, ClassLoader classLoader, Parser parser) throws IOException {
@@ -120,10 +119,6 @@ public class AppClientScanner extends ModuleScanner<ApplicationClientDescriptor>
             addScanClassName(desc.getCallbackHandler());
         }
 
-        GenericAnnotationDetector detector =
-            new GenericAnnotationDetector(managedBeanAnnotations);
-
-        if (detector.hasAnnotationInArchive(archive)) {
             if (archive instanceof FileArchive) {
                 addScanDirectory(new File(archive.getURI()));
             } else if (archive instanceof InputJarArchive) {
@@ -143,7 +138,6 @@ public class AppClientScanner extends ModuleScanner<ApplicationClientDescriptor>
                  */
                 addScanURI(scanURI(((MultiReadableArchive) archive).getURI(1)));
             }
-        }
 
         this.classLoader = classLoader;
         this.archiveFile = null; // = archive;

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/build.xml
@@ -71,7 +71,7 @@
     <target name="build" depends="compile">
         <antcall target="build-ear-common">
             <param name="ejbjar.classes" value="**/MySessionBean*.class, **/*MessageBean.class" />
-            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBean*.class" />
+            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBeanRemote.class" />
         </antcall>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/ejb/MySessionBeanRemote.java
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/ejb/MySessionBeanRemote.java
@@ -44,7 +44,7 @@ import javax.ejb.Remote;
 
 @Remote
 public interface MySessionBeanRemote {
-    public static final String RemoteJNDIName =  MySessionBean.class.getSimpleName() + "/remote";
+    public static final String RemoteJNDIName =  "MySessionBean/remote";
 
     public void sendMessage(String text);
 


### PR DESCRIPTION
Fixes #22122
Earlier in AppClientScanner, annotations are processed if and only if there are managed beans in the bundle. I have disabled that check for presence of managed bean such that annotations are processed in all cases.