### PR TITLE
Fixes #22132 : Allow admin console to take a default context path of a web application as context root.

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -1945,7 +1945,7 @@ admingui.deploy = {
             //may as well set context root if it exist.
             var component = obj.document.getElementById(contextRootId);
             if (component != null){
-                component.value = appName;
+                component.value = '';
             }
         }
     },

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -830,7 +830,7 @@ webApp.descriptorPageTitleHelp=View module descriptors for the Web application.
 webApp.targetPageTitle=Web Applications Targets
 webApp.targetPageTitleHelp=Manage the targets (clusters and stand-alone server instances) on which the web application is available.
 webApp.ContextRoot=Context Root:
-webApp.contextRootHelp=Path relative to server's base URL.
+webApp.contextRootHelp=Path relative to server's base URL. If empty, takes the default context path of a web application.
 webApp.viewDDPageTitle=View Deployment Descriptor
 
 resourcesPageTitle=Resources

--- a/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/ApplicationTest.java
+++ b/appserver/admingui/devtests/src/test/java/org/glassfish/admingui/devtests/ApplicationTest.java
@@ -96,10 +96,10 @@ public class ApplicationTest extends BaseSeleniumTestClass {
             e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
         }
 
-        assertEquals("test", getFieldValue(ELEMENT_CONTEXT_ROOT));
+        assertEquals("", getFieldValue(ELEMENT_CONTEXT_ROOT));
         assertEquals("test", getFieldValue(ELEMENT_APP_NAME));
 
-        setFieldValue(ELEMENT_CONTEXT_ROOT, applicationName);
+        setFieldValue(ELEMENT_CONTEXT_ROOT, "");
         setFieldValue(ELEMENT_APP_NAME, applicationName);
 
         clickAndWait(ELEMENT_UPLOAD_BUTTON, TRIGGER_APPLICATIONS);


### PR DESCRIPTION
In console, made context root as empty by default. If it is empty, backend takes care of assigning the default context path. 
Changed help text of a context root accordingly.