### PR TITLE
Fixes #22131 : Improper message from start-domain

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
@@ -109,9 +109,6 @@ MutuallyExclusiveOption=CLI169: Options {0} and {1} are mutually exclusive.  You
 UnsupportedLegacyCommand=CLI194: Previously supported command: {0} is not supported for this release.
 NoScope=CLI195: Implementation for the command {0} exists in the system,\nbut it has no @Scoped annotation
 HasParams=CLI196: Implementation for the command {0} exists in the system,\nbut it's a singleton that also has parameters
-NullNewPassword=CLI197: New password must not be null when secure-admin is enabled.
-NotFileRealmCannotChangeLocally=CLI198: The admin realm is not a file based realm.The admin password cannot be changed locally.
-CannotExecuteLocally=CLI199: This command cannot be executed locally.
 
 ###
 listCommands.notBoth=You can't specify both --localonly and --remoteonly as true at the same time.
@@ -168,8 +165,6 @@ ObsoleteOption=CLI031: Warning: Option "{0}" is obsolete and will be ignored.
 PasswordsNotAllowedOnCommandLine=CLI193: Password option "{0}" is not allowed on the command line. Please use the --passwordfile option or the admin command's login sub-command.
 commands.monitor.press_to_quit=Press 'q' or 'Q' to quit.
 InvalidRemoteCommand=No such local command: {0}.  Unable to access the server to execute the command remotely.  Verify the server is available. 
-NoAdminPort=Cannot find admin port in domain.xml file
-NoAdminPortEx=Cannot find admin port in domain.xml file, caused by:\n  {0}
 
 remote.version.failed=Version string could not be obtained from Server [{0}:{1}].
 remote.version.failed.debug= (Turn debugging on e.g. by setting {0}=true in your environment, to see the details.)
@@ -219,14 +214,7 @@ stopwatch=Total Time to Launch: {0} msec
 token.unbalancedQuotes=Unbalanced quotes
 token.escapeAtEOL=Escape at end of line
 token.noMoreTokens=No more tokens
-deathwait_timeout=Waited {0} milliseconds for the server to die.  It did not die.  Can not restart.  Please kill it manually.
 runscript.badport=Bad httpport argument({0}).  It must be an integer between 1 and 65535 inclusive.
 runscript.noscriptname=The java script filename is required.
 runscript.badscriptname=The java script filename({0}) does not exist.
 internal_error=Internal Error: {0}
-DAS=Domain Administration Server
-INSTANCE=Instance Server
-serverNoStart=No response from the {0} ({1}) after {2} seconds.\n\
-The command is either taking too long to complete or the server has failed.\n\
-Please see the server log files for command status.  \n\
-Please start with the --verbose option in order to see early messages.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/LocalStrings.properties
@@ -96,16 +96,3 @@ runtimeStatusToStringStartCluster.error=The clustered instance, {0}, could not b
 
 CertificateDN=Distinguished Name of the self-signed X.509 Server Certificate is:\n[{0}]
 SomeProblemWithKeytool= Domain creation process involves a step that creates primary key and\n self-signed server certificate. This step failed for the reason shown below.\n This could be because JDK provided keytool program could not be found (e.g.\n you are running with JRE) or for some other reason. No need to panic, as you\n can always use JDK-keytool program to do the needful. A temporary JKS-keystore\n will be created. You should replace it with proper keystore before using it for SSL.\n Refer to documentation for details. Actual error is:\n{0}
-
-DAS=Domain Administration Server
-INSTANCE=Instance Server
-serverNoStart=No response from the {0} ({1}) after {2} seconds.\n\
-The command is either taking too long to complete or the server has failed.\n\
-Please see the server log files for command status.  \n\
-Please start with the --verbose option in order to see early messages.
-deathwait_timeout=Waited {0} milliseconds for the server to die.  It did not die.  Can not restart.  Please kill it manually.
-NullNewPassword=CLI197: New password must not be null when secure-admin is enabled.
-NotFileRealmCannotChangeLocally=CLI198: The admin realm is not a file based realm.The admin password cannot be changed locally.
-CannotExecuteLocally=CLI199: This command cannot be executed locally.
-NoAdminPort=Cannot find admin port in domain.xml file
-NoAdminPortEx=Cannot find admin port in domain.xml file, caused by:\n  {0}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/LocalStrings.properties
@@ -96,3 +96,16 @@ runtimeStatusToStringStartCluster.error=The clustered instance, {0}, could not b
 
 CertificateDN=Distinguished Name of the self-signed X.509 Server Certificate is:\n[{0}]
 SomeProblemWithKeytool= Domain creation process involves a step that creates primary key and\n self-signed server certificate. This step failed for the reason shown below.\n This could be because JDK provided keytool program could not be found (e.g.\n you are running with JRE) or for some other reason. No need to panic, as you\n can always use JDK-keytool program to do the needful. A temporary JKS-keystore\n will be created. You should replace it with proper keystore before using it for SSL.\n Refer to documentation for details. Actual error is:\n{0}
+
+DAS=Domain Administration Server
+INSTANCE=Instance Server
+serverNoStart=No response from the {0} ({1}) after {2} seconds.\n\
+The command is either taking too long to complete or the server has failed.\n\
+Please see the server log files for command status.  \n\
+Please start with the --verbose option in order to see early messages.
+deathwait_timeout=Waited {0} milliseconds for the server to die.  It did not die.  Can not restart.  Please kill it manually.
+NullNewPassword=CLI197: New password must not be null when secure-admin is enabled.
+NotFileRealmCannotChangeLocally=CLI198: The admin realm is not a file based realm.The admin password cannot be changed locally.
+CannotExecuteLocally=CLI199: This command cannot be executed locally.
+NoAdminPort=Cannot find admin port in domain.xml file
+NoAdminPortEx=Cannot find admin port in domain.xml file, caused by:\n  {0}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -241,3 +241,17 @@ change.admin.password.newpassword.again=Enter the new admin password again
 
 ## LocalServerCommand
 NoServerDirs=Internal Error: setServerDirs() was never called, so the server dirs is null.
+
+
+DAS=Domain Administration Server
+INSTANCE=Instance Server
+serverNoStart=No response from the {0} ({1}) after {2} seconds.\n\
+The command is either taking too long to complete or the server has failed.\n\
+Please see the server log files for command status.  \n\
+Please start with the --verbose option in order to see early messages.
+deathwait_timeout=Waited {0} milliseconds for the server to die.  It did not die.  Can not restart.  Please kill it manually.
+NullNewPassword=CLI197: New password must not be null when secure-admin is enabled.
+NotFileRealmCannotChangeLocally=CLI198: The admin realm is not a file based realm.The admin password cannot be changed locally.
+CannotExecuteLocally=CLI199: This command cannot be executed locally.
+NoAdminPort=Cannot find admin port in domain.xml file
+NoAdminPortEx=Cannot find admin port in domain.xml file, caused by:\n  {0}


### PR DESCRIPTION
Fixes #22131 : 
Few key-value pairs of nucleus/admin/server-mgmt module were present in the resource bundle of a different module(nucleus/admin/cli), hence moving it to the right resource bundle.