### PR TITLE
Update jettison version to 1.3.8

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -150,7 +150,7 @@
         <ant.version>1.10.1</ant.version>
         <jersey.version>2.26-b08</jersey.version>
         <jackson.version>2.8.4</jackson.version>
-        <jettison.version>1.3.3</jettison.version>
+        <jettison.version>1.3.8</jettison.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1-m09</jax-rs-api.impl.version>
         <mimepull.version>1.9.7</mimepull.version>


### PR DESCRIPTION
The suggested fix updates jettison dependency version to 1.3.8