### PR TITLE
Adding permission required for Derby 10.13.1.1

### DIFF
--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -144,3 +144,7 @@ grant  codeBase "file:${com.sun.aas.instanceRoot}/applications/-"{
     permission java.io.FilePermission       "<<ALL FILES>>", "read,write";
     permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
 };
+//For Derby 10.12.1.1
+grant {
+     permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";
+};

--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -144,7 +144,7 @@ grant  codeBase "file:${com.sun.aas.instanceRoot}/applications/-"{
     permission java.io.FilePermission       "<<ALL FILES>>", "read,write";
     permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
 };
-//For Derby 10.12.1.1
+//Added for changes proposed by Derby 10.12.1.1 (DERBY-6648)
 grant {
      permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";
 };


### PR DESCRIPTION
Fixes #22160  Updating server.policy required for Derby 10.13.1.1. 