### PR TITLE
Fix #22163: Add logging info that we are skipping resource validation

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ResourceValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ResourceValidator.java
@@ -83,6 +83,9 @@ public class ResourceValidator implements EventListener, ResourceValidatorVisito
     )
     private static final String RESOURCE_REF_JNDI_LOOKUP_FAILED = "AS-DEPLOYMENT-00026";
 
+    @LogMessageInfo(message = "Skipping resource validation")
+    private static final String SKIP_RESOURCE_VALIDATION = "AS-DEPLOYMENT-00028";
+
     private String target;
 
     private DeploymentContext dc;
@@ -111,7 +114,11 @@ public class ResourceValidator implements EventListener, ResourceValidatorVisito
             application = dc.getModuleMetaData(Application.class);
             DeployCommandParameters commandParams = dc.getCommandParameters(DeployCommandParameters.class);
             target = commandParams.target;
-            if (application == null || System.getProperty("deployment.resource.validation", "true").equals("false"))
+            if (System.getProperty("deployment.resource.validation", "true").equals("false")) {
+                deplLogger.log(Level.INFO, SKIP_RESOURCE_VALIDATION);
+                return;
+            }
+            if (application == null)
                 return;
             AppResources appResources = new AppResources();
             parseResources(appResources);


### PR DESCRIPTION
Fix #22163: If the jvm property `-Ddeployment.resource.validation=false` is set, a message such as this would be logged in server.log for each deployment
```
[2017-08-03T14:35:23.801+0530] [glassfish 5.0] [INFO] [AS-DEPLOYMENT-00028] [javax.enterprise.system.tools.deployment.dol] [tid: _ThreadID=46 _ThreadName=admin-listener(3)] [timeMillis: 1501751123801] [levelValue: 800] [[
  Skipping resource validation]]
```