### PR TITLE
Fix #22174: Remove EJB class from app client jar

### DIFF
--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/build.xml
@@ -71,7 +71,7 @@
     <target name="build" depends="compile">
         <antcall target="build-ear-common">
             <param name="ejbjar.classes" value="**/MySessionBean*.class, **/*MessageBean.class" />
-            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBean*.class" />
+            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBeanRemote.class" />
         </antcall>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/ejb/MySessionBeanRemote.java
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/ejb/MySessionBeanRemote.java
@@ -44,7 +44,7 @@ import javax.ejb.Remote;
 
 @Remote
 public interface MySessionBeanRemote {
-    public static final String RemoteJNDIName =  MySessionBean.class.getSimpleName() + "/remote";
+    public static final String RemoteJNDIName = "MySessionBean/remote";
 
     public void sendMessage(String text);
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/build.xml
@@ -71,7 +71,7 @@
     <target name="build" depends="compile">
         <antcall target="build-ear-common">
             <param name="ejbjar.classes" value="**/MySessionBean*.class, **/*MessageBean.class" />
-            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBean*.class" />
+            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBeanRemote.class" />
         </antcall>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/ejb/MySessionBeanRemote.java
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/ejb/MySessionBeanRemote.java
@@ -44,7 +44,7 @@ import javax.ejb.Remote;
 
 @Remote
 public interface MySessionBeanRemote {
-    public static final String RemoteJNDIName =  MySessionBean.class.getSimpleName() + "/remote";
+    public static final String RemoteJNDIName = "MySessionBean/remote";
 
     public void sendMessage(String text);
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
@@ -78,7 +78,7 @@
     <target name="build" depends="compile">
         <antcall target="build-ear-common">
             <param name="ejbjar.classes" value="**/MySessionBean*.class" />
-            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBean*.class" />
+            <param name="appclientjar.classes" value="**/*Client.class,**/MySessionBeanRemote.class" />
         </antcall>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/ejb/MySessionBeanRemote.java
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/ejb/MySessionBeanRemote.java
@@ -44,7 +44,7 @@ import javax.ejb.Remote;
 
 @Remote
 public interface MySessionBeanRemote {
-    public static final String RemoteJNDIName =  MySessionBean.class.getSimpleName() + "/remote";
+    public static final String RemoteJNDIName =  "MySessionBean/remote";
 
     public void sendMessage(String text);
 


### PR DESCRIPTION
Fix #22174: Remove EJB classes from app client jars in the `devtests/jms/annotation` sub-directory