### PR TITLE
Fix #22180: Skip processing of EJB class files if packaged in an app client

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/AppClientScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/AppClientScanner.java
@@ -169,7 +169,7 @@ public class AppClientScanner extends ModuleScanner<ApplicationClientDescriptor>
     }
 
     /**
-     * Overriding to handle the case where EJB class is mistakenly packages inside an appclient jar.
+     * Overriding to handle the case where EJB class is mistakenly packaged inside an appclient jar.
      * Instead of throwing an error which might raise backward compatiability issues, a cleaner way is to
      * just skip the annotation processing for them.
      */
@@ -177,7 +177,12 @@ public class AppClientScanner extends ModuleScanner<ApplicationClientDescriptor>
     protected void calculateResults(ApplicationClientDescriptor bundleDesc) {
         super.calculateResults(bundleDesc);
 
-        Class[] ejbAnnotations = ejbProvider.getAnnotationTypes();
+        Class[] ejbAnnotations;
+        if (ejbProvider != null)
+            ejbAnnotations = ejbProvider.getAnnotationTypes();
+        else
+            ejbAnnotations = new Class[] {javax.ejb.Stateful.class, javax.ejb.Stateless.class,
+                    javax.ejb.MessageDriven.class, javax.ejb.Singleton.class};
         Set<String> toBeRemoved = new HashSet<String>();
         ParsingContext context = classParser.getContext();
         for (Class ejbAnnotation: ejbAnnotations) {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
@@ -89,13 +89,13 @@ public abstract class ModuleScanner<T> extends JavaEEScanner implements Scanner<
     protected ClassLoader classLoader = null;
     protected Parser classParser = null;
 
-    private Set<URI> scannedURI = new HashSet<URI>();
+    protected Set<URI> scannedURI = new HashSet<URI>();
 
     private boolean needScanAnnotation = false;
 
     private static ExecutorService executorService = null;
     
-    private Set<String> entries = new HashSet<String>();
+    protected Set<String> entries = new HashSet<String>();
 
     public static final Logger deplLogger = com.sun.enterprise.deployment.util.DOLUtils.deplLogger;
 


### PR DESCRIPTION
Fixes #22180, Avoids issues such as #22174 in the future.