### PR TITLE
Fixes #22138 : Help for --contextroot of asadmin deploy should include default-context-path

### DIFF
--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
@@ -67,7 +67,8 @@ OPTIONS
 
        --contextroot
            Valid only if the archive is a web module. It is ignored for other
-           archive types; defaults to filename without extension.
+           archive types; it will be the value specified by default-context-path
+           in web.xml, if specified; defaults to filename without extension.
 
        --precompilejsp
            By default this option does not allow the JSP to be precompiled

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
@@ -83,7 +83,8 @@ OPTIONS
 
        --contextroot
            Valid only if the archive is a web module. It is ignored for other
-           archive types; defaults to filename without extension.
+           archive types; it will be the value specified by default-context-path
+           in web.xml, if specified; defaults to filename without extension.
 
        --precompilejsp
            By default this option does not allow the JSP to be precompiled

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
@@ -52,7 +52,8 @@ OPTIONS
 
        --contextroot
            Valid only if the archive is a web module. It is ignored for other
-           archive types; defaults to filename without extension.
+           archive types; it will be the value specified by default-context-path
+           in web.xml, if specified; defaults to filename without extension.
 
        --precompilejsp
            By default this option does not allow the JSP to be precompiled


### PR DESCRIPTION
Fixes #22138.