### PR TITLE
Fixes #20199 - BATCH CLI: asadmin set-batch-runtime-configuration --help command shows incorrect examples

### DIFF
--- a/appserver/batch/glassfish-batch-commands/src/main/manpages/org/glassfish/batch/set-batch-runtime-configuration.1
+++ b/appserver/batch/glassfish-batch-commands/src/main/manpages/org/glassfish/batch/set-batch-runtime-configuration.1
@@ -60,7 +60,7 @@ EXAMPLES
            server instance to use an existing managed executor service named
            concurrent/myExecutor.
 
-               asadmin> configure-batch-runtime --executorservicelookupname concurrent/myExecutor
+               asadmin> set-batch-runtime-configuration --executorservicelookupname concurrent/myExecutor
                Command set-batch-runtime-configuration executed successfully.
 
 EXIT STATUS


### PR DESCRIPTION
Fixes #20199 