### PR TITLE
NoBug: Integrate latest JSR 375 API and RI (soteria) 1.0-b11 in glassfish 5.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -82,8 +82,8 @@
         <javax.security.auth.message-api.version>1.1</javax.security.auth.message-api.version>
         <!-- Ensure that nucleus/pom.xml's javax.validation property is of same value as the one below -->
         <javax.validation-api.version>2.0.0.CR3</javax.validation-api.version>
-        <javax.security.enterprise-api.version>1.0-b09</javax.security.enterprise-api.version>
-        <javax.security.enterprise.version>1.0-b10</javax.security.enterprise.version>
+        <javax.security.enterprise-api.version>1.0-b11</javax.security.enterprise-api.version>
+        <javax.security.enterprise.version>1.0-b11</javax.security.enterprise.version>
 
         <product.name>GlassFish Server Open Source Edition</product.name>
         <brief_product_name>GlassFish Server</brief_product_name>

--- a/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/PlaintextPasswordHash.java
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/app-db/src/main/java/org/glassfish/soteria/test/PlaintextPasswordHash.java
@@ -37,31 +37,32 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+ 
 package org.glassfish.soteria.test;
+import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
-import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import javax.enterprise.context.Dependent;
+import javax.security.enterprise.identitystore.PasswordHash;
 
-@DatabaseIdentityStoreDefinition(
-    dataSourceLookup="${'jdbc/__default'}", 
-    callerQuery="#{'select password from caller where name = ?'}",
-    groupsQuery="select group_name from caller_groups where caller_name = ?",
-    hashAlgorithm = PlaintextPasswordHash.class,
-    hashAlgorithmParameters = {
-        "foo=bar", 
-        "kax=zak", 
-        "foox=${'iop'}",
-        "${applicationConfig.dyna}"
-        
-    } // just for test / example
-)
-@ApplicationScoped
-@Named
-public class ApplicationConfig {
-    
-    public String[] getDyna() {
-        return new String[] {"dyn=1","dyna=2","dynam=3"};
+@Dependent
+public class PlaintextPasswordHash implements PasswordHash {
+
+    @Override
+    public void initialize(Map<String, String> parameters) {
+
     }
-    
+
+    @Override
+    public String generate(char[] password) {
+        return new String(password);
+    }
+
+    @Override
+    public boolean verify(char[] password, String hashedPassword) {
+         //don't bother with constant time comparison; more portable
+         //this way, and algorithm will be used only for testing.
+        return (password != null && password.length > 0 &&
+                hashedPassword != null && hashedPassword.length() > 0 &&
+                hashedPassword.equals(new String(password)));
+    }
 }

--- a/appserver/tests/appserv-tests/devtests/security/soteria/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/pom.xml
@@ -45,7 +45,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.glassfish.main</groupId>
-        <artifactId>glassfish-nucleus-parent</artifactId>
+        <artifactId>glassfish-parent</artifactId>
         <version>5.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
@@ -113,13 +113,13 @@
         <dependency>
             <groupId>javax.security.enterprise</groupId>
             <artifactId>javax.security.enterprise-api</artifactId>
-            <version>1.0-b09</version>
+            <version>${javax.security.enterprise-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
             <artifactId>javax.security.enterprise</artifactId>
-            <version>1.0-b10</version>
+            <version>${javax.security.enterprise.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Changes:

- Update RI and API to 1.0-b11 
- Use appserver/pom.xml as parent pom and use ri and app versions from there.
- PlaintextPasswordHash has been removed from api, so use app local one.
