### PR TITLE
Integrate JASPIC and Security API in EE web profile API.

### DIFF
--- a/appserver/javaee-api/javax.javaee-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-api/pom.xml
@@ -182,11 +182,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.security.auth.message</groupId>
-            <artifactId>javax.security.auth.message-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise.concurrent</groupId>
             <artifactId>javax.enterprise.concurrent-api</artifactId>
             <optional>true</optional>

--- a/appserver/javaee-api/javax.javaee-web-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-web-api/pom.xml
@@ -73,7 +73,8 @@
     
     <properties>
         <!-- we don't process the rpc classes inlined in ejb-api -->
-        <extra.excludes>javax/xml/rpc/**</extra.excludes>
+        <!-- do NOT pacakge javax.resource and javax.security.jacc as part of web api -->
+        <extra.excludes>javax/xml/rpc/**,javax/resource/**,javax/security/jacc/**</extra.excludes>
     </properties>
 
     <build>
@@ -221,6 +222,26 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>javax.resource-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.security.jacc</groupId>
+            <artifactId>javax.security.jacc-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.security.auth.message</groupId>
+            <artifactId>javax.security.auth.message-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.security.enterprise</groupId>
+            <artifactId>javax.security.enterprise-api</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/javaee-api/javax.javaee-web-api/pom.xml
+++ b/appserver/javaee-api/javax.javaee-web-api/pom.xml
@@ -73,8 +73,7 @@
     
     <properties>
         <!-- we don't process the rpc classes inlined in ejb-api -->
-        <!-- do NOT pacakge javax.resource and javax.security.jacc as part of web api -->
-        <extra.excludes>javax/xml/rpc/**,javax/resource/**,javax/security/jacc/**</extra.excludes>
+        <extra.excludes>javax/xml/rpc/**</extra.excludes>
     </properties>
 
     <build>
@@ -222,16 +221,6 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>javax.resource-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>javax.security.jacc</groupId>
-            <artifactId>javax.security.jacc-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/javaee-api/pom.xml
+++ b/appserver/javaee-api/pom.xml
@@ -209,6 +209,17 @@
     <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
 ]]>
                         </bottom>
+                        <links>
+                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>http://docs.oracle.com/javaee/7/api/</link>
+                        </links>
+                        <tags>
+                            <tag>
+                                <name>implSpec</name>
+                                <placement>a</placement>
+                                <head>Implementation Specification:</head>
+                            </tag>
+                        </tags>
                     </configuration>
                 </plugin>
             </plugins>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -82,7 +82,7 @@
         <javax.security.auth.message-api.version>1.1</javax.security.auth.message-api.version>
         <!-- Ensure that nucleus/pom.xml's javax.validation property is of same value as the one below -->
         <javax.validation-api.version>2.0.0.CR3</javax.validation-api.version>
-        <javax.security.enterprise-api.version>1.0-b11</javax.security.enterprise-api.version>
+        <javax.security.enterprise-api.version>1.0-b12</javax.security.enterprise-api.version>
         <javax.security.enterprise.version>1.0-b11</javax.security.enterprise.version>
 
         <product.name>GlassFish Server Open Source Edition</product.name>


### PR DESCRIPTION
Fixes #22206 
- Add JASPIC and Security API in web api pom.
- remove JASPIC from full-profile pom.
- Add apidocs links to se 8 and ee 7.
- Update JSR 375 api to 1.0-b12