### PR TITLE
Fix #22156: Bug in annotation handling in case of container annotation handlers

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionHandler.java
@@ -49,6 +49,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.interceptor.AroundInvoke;
@@ -69,7 +70,10 @@ import java.util.logging.Level;
 @AnnotationHandlerFor(AdministeredObjectDefinition.class)
 public class AdministeredObjectDefinitionHandler extends AbstractResourceHandler {
     
-    public AdministeredObjectDefinitionHandler() {
+    public AdministeredObjectDefinitionHandler() {}
+
+    public AdministeredObjectDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
     }
 
     @Override

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionsHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/AdministeredObjectDefinitionsHandler.java
@@ -69,8 +69,7 @@ public class AdministeredObjectDefinitionsHandler extends AbstractResourceHandle
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(AdministeredObjectDefinitionsHandler.class);
 
-    public AdministeredObjectDefinitionsHandler() {
-    }
+    public AdministeredObjectDefinitionsHandler() {}
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo,  ResourceContainerContext[] rcContexts)
@@ -92,7 +91,7 @@ public class AdministeredObjectDefinitionsHandler extends AbstractResourceHandle
                 }else{
                     duplicates.add(defnName);
                 }
-                AdministeredObjectDefinitionHandler handler = new AdministeredObjectDefinitionHandler();
+                AdministeredObjectDefinitionHandler handler = new AdministeredObjectDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionHandler.java
@@ -49,6 +49,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.interceptor.AroundInvoke;
@@ -69,10 +70,11 @@ import java.util.logging.Level;
 @AnnotationHandlerFor(ConnectionFactoryDefinition.class)
 public class ConnectionFactoryDefinitionHandler extends AbstractResourceHandler {
 
-    
-    public ConnectionFactoryDefinitionHandler() {
-    }
+    public ConnectionFactoryDefinitionHandler() {}
 
+    public ConnectionFactoryDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
+    }
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo, ResourceContainerContext[] rcContexts)

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionsHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/deployment/annotation/handlers/ConnectionFactoryDefinitionsHandler.java
@@ -68,10 +68,7 @@ public class ConnectionFactoryDefinitionsHandler extends AbstractResourceHandler
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(ConnectionFactoryDefinitionsHandler.class);
 
-    
-    public ConnectionFactoryDefinitionsHandler() {
-    }
-
+    public ConnectionFactoryDefinitionsHandler() {}
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo,  ResourceContainerContext[] rcContexts)
@@ -98,7 +95,7 @@ public class ConnectionFactoryDefinitionsHandler extends AbstractResourceHandler
                 }else{
                     duplicates.add(defnName);
                 }
-                ConnectionFactoryDefinitionHandler handler = new ConnectionFactoryDefinitionHandler();
+                ConnectionFactoryDefinitionHandler handler = new ConnectionFactoryDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractResourceHandler.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/AbstractResourceHandler.java
@@ -51,6 +51,7 @@ import org.glassfish.apf.AnnotatedElementHandler;
 import org.glassfish.apf.AnnotationInfo;
 import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -71,6 +72,14 @@ import java.lang.reflect.Method;
  * @author Shing Wai Chan
  */
 public abstract class AbstractResourceHandler extends AbstractHandler {
+
+    protected AbstractResourceHandler() {
+    }
+
+    protected AbstractResourceHandler(AnnotationTypesProvider ejbProvider) {
+        this.ejbProvider = ejbProvider;
+    }
+
     /**
      * Process Annotation with given ResourceContainerContexts.
      * @param ainfo

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
@@ -49,6 +49,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.annotation.sql.DataSourceDefinition;
@@ -68,7 +69,10 @@ import java.util.logging.Level;
 @AnnotationHandlerFor(DataSourceDefinition.class)
 public class DataSourceDefinitionHandler extends AbstractResourceHandler {
 
-    public DataSourceDefinitionHandler() {
+    public DataSourceDefinitionHandler() {}
+
+    public DataSourceDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
     }
 
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo, ResourceContainerContext[] rcContexts)

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionsHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionsHandler.java
@@ -94,7 +94,7 @@ public class DataSourceDefinitionsHandler extends AbstractResourceHandler {
                 }else{
                     duplicates.add(defnName);
                 }
-                DataSourceDefinitionHandler handler = new DataSourceDefinitionHandler();
+                DataSourceDefinitionHandler handler = new DataSourceDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionHandler.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionHandler.java
@@ -49,6 +49,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.interceptor.AroundInvoke;
@@ -66,7 +67,10 @@ import java.util.logging.Level;
 @AnnotationHandlerFor(JMSConnectionFactoryDefinition.class)
 public class JMSConnectionFactoryDefinitionHandler extends AbstractResourceHandler {
 
-    public JMSConnectionFactoryDefinitionHandler() {
+    public JMSConnectionFactoryDefinitionHandler() {}
+
+    public JMSConnectionFactoryDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
     }
 
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo, ResourceContainerContext[] rcContexts)

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionsHandler.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSConnectionFactoryDefinitionsHandler.java
@@ -56,6 +56,7 @@ import org.glassfish.apf.AnnotationHandlerFor;
 import org.glassfish.apf.AnnotationInfo;
 import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
@@ -65,9 +66,7 @@ public class JMSConnectionFactoryDefinitionsHandler extends AbstractResourceHand
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(JMSConnectionFactoryDefinitionsHandler.class);
 
-
-    public JMSConnectionFactoryDefinitionsHandler() {
-    }
+    public JMSConnectionFactoryDefinitionsHandler() {}
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo,  ResourceContainerContext[] rcContexts)
@@ -88,7 +87,7 @@ public class JMSConnectionFactoryDefinitionsHandler extends AbstractResourceHand
                 } else {
                     duplicates.add(defnName);
                 }
-                JMSConnectionFactoryDefinitionHandler handler = new JMSConnectionFactoryDefinitionHandler();
+                JMSConnectionFactoryDefinitionHandler handler = new JMSConnectionFactoryDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionHandler.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionHandler.java
@@ -49,6 +49,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.interceptor.AroundInvoke;
@@ -66,7 +67,10 @@ import java.util.logging.Level;
 @AnnotationHandlerFor(JMSDestinationDefinition.class)
 public class JMSDestinationDefinitionHandler extends AbstractResourceHandler {
 
-    public JMSDestinationDefinitionHandler() {
+    public JMSDestinationDefinitionHandler() {}
+
+    public JMSDestinationDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
     }
 
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo, ResourceContainerContext[] rcContexts)

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionsHandler.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/deployment/annotation/handlers/JMSDestinationDefinitionsHandler.java
@@ -65,9 +65,7 @@ public class JMSDestinationDefinitionsHandler extends AbstractResourceHandler {
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(JMSDestinationDefinitionsHandler.class);
 
-
-    public JMSDestinationDefinitionsHandler() {
-    }
+    public JMSDestinationDefinitionsHandler() {}
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo,  ResourceContainerContext[] rcContexts)
@@ -88,7 +86,7 @@ public class JMSDestinationDefinitionsHandler extends AbstractResourceHandler {
                 } else {
                     duplicates.add(defnName);
                 }
-                JMSDestinationDefinitionHandler handler = new JMSDestinationDefinitionHandler();
+                JMSDestinationDefinitionHandler handler = new JMSDestinationDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();

--- a/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionHandler.java
+++ b/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionHandler.java
@@ -50,6 +50,7 @@ import org.glassfish.apf.AnnotationProcessorException;
 import org.glassfish.apf.HandlerProcessingResult;
 import org.glassfish.deployment.common.JavaEEResourceType;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
+import org.glassfish.internal.deployment.AnnotationTypesProvider;
 import org.jvnet.hk2.annotations.Service;
 
 import javax.interceptor.AroundInvoke;
@@ -78,8 +79,10 @@ public class MailSessionDefinitionHandler extends AbstractResourceHandler {
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(MailSessionDefinitionHandler.class);
 
-    public MailSessionDefinitionHandler() {
+    public MailSessionDefinitionHandler() {}
 
+    public MailSessionDefinitionHandler(AnnotationTypesProvider ejbProvider) {
+        super(ejbProvider);
     }
 
     @Override

--- a/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionsHandler.java
+++ b/appserver/resources/javamail/javamail-runtime/src/main/java/org/glassfish/resources/javamail/annotation/handler/MailSessionDefinitionsHandler.java
@@ -71,9 +71,7 @@ public class MailSessionDefinitionsHandler extends AbstractResourceHandler {
     protected final static LocalStringManagerImpl localStrings =
             new LocalStringManagerImpl(MailSessionDefinitionsHandler.class);
 
-    public MailSessionDefinitionsHandler() {
-
-    }
+    public MailSessionDefinitionsHandler() {}
 
     @Override
     protected HandlerProcessingResult processAnnotation(AnnotationInfo ainfo, ResourceContainerContext[] rcContexts) throws AnnotationProcessorException {
@@ -94,7 +92,7 @@ public class MailSessionDefinitionsHandler extends AbstractResourceHandler {
                 } else {
                     duplicates.add(defnName);
                 }
-                MailSessionDefinitionHandler handler = new MailSessionDefinitionHandler();
+                MailSessionDefinitionHandler handler = new MailSessionDefinitionHandler(ejbProvider);
                 handler.processAnnotation(defn, ainfo, rcContexts);
             }
             duplicates.clear();


### PR DESCRIPTION
Reopening PR #22164 

Fix #22156 - Using a plural annotation such as AdministeredObjectDefinitionsHandler would lead to a call to the processAnnotation function of its singular version AdministeredObjectDefinitionHandler. During this, the ejbProvider is not passed properly leading to a bug in the handling of these annotations.

I have added an additional constructor to facilitate this. Changed the code in all plural annotation handlers.