### PR TITLE
Fix #22209: Integrate JPA 2.2.0-RC3/EclipseLink 2.7.0-RC3

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -109,8 +109,8 @@
         <jaxb.version>2.3.0</jaxb.version>
         <stax2-api.version>3.1.4</stax2-api.version>
         <javax.xml.registry-api.version>1.0.7</javax.xml.registry-api.version>
-        <eclipselink.version>2.7.0-RC1</eclipselink.version>
-        <javax-persistence-api.version>2.2.0-RC1</javax-persistence-api.version>
+        <eclipselink.version>2.7.0-RC3</eclipselink.version>
+        <javax-persistence-api.version>2.2.0-RC3</javax-persistence-api.version>
         <dbschema.version>3.1.1</dbschema.version>
         <dbschema.osgi.version>6.0</dbschema.osgi.version>
         <schema2beans.version>3.1.1</schema2beans.version>


### PR DESCRIPTION
Fixes #22209 