### PR TITLE
Using bean-validator-cdi generated by GlassFish

### DIFF
--- a/appserver/packager/glassfish-jcdi/pom.xml
+++ b/appserver/packager/glassfish-jcdi/pom.xml
@@ -104,9 +104,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-   	    <groupId>org.glassfish.hk2.external</groupId>
+   	    <groupId>org.glassfish.main.external</groupId>
     	    <artifactId>bean-validator-cdi</artifactId>
-	    <version>${bean.validator.cdi.version}</version>
+	    <version>${project.version}</version>
     	</dependency>
 	<dependency>
             <groupId>javax.enterprise</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -134,8 +134,7 @@
         <com.ibm.jbatch.spi.version>1.0.2</com.ibm.jbatch.spi.version>
         <javax.management.j2ee-api.version>1.1.1</javax.management.j2ee-api.version>
         <guava.version>13.0.1</guava.version>
-	<bean.validator.cdi.version>2.5.0-b06</bean.validator.cdi.version>
-	 <jboss.classfilewriter.version>1.2.1.Final</jboss.classfilewriter.version>
+	<jboss.classfilewriter.version>1.2.1.Final</jboss.classfilewriter.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Fixing #22226 : Updating bean validator cdi version and using the one generated by GlassFish