### PR TITLE
add privileged block in logout

### DIFF
--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -517,7 +517,12 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
     @Override
     public void logout() {
         setSecurityContext(null);
-        resetPolicyContext();
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            public Void run() {
+                resetPolicyContext();
+                return null;
+            }
+        });
     }
 
     public Principal authenticate(HttpServletRequest hreq) {


### PR DESCRIPTION
Fixes #22243

```java
    private void resetPolicyContext() {
       ((PolicyContextHandlerImpl)PolicyContextHandlerImpl.getInstance()).reset();
       PolicyContext.setContextID(null);
    }
```
The issue stacktrace catches permission issue PolicyContextHandlerImpl.getInstance(), but  PolicyContext.setContextID() also need setPolicy permissions as per [javadoc](http://docs.oracle.com/javaee/7/api/javax/security/jacc/PolicyContext.html#setContextID-java.lang.String-)
which why the doPrivileged for whole resetPolicyContext().