### PR TITLE
Fix for incorrect image description issue

### DIFF
--- a/appserver/admingui/community-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/community-theme/src/main/resources/branding/masthead.inc
@@ -40,6 +40,10 @@
 
 -->
 
+<!initPage
+    setResourceBundle(key="theme" bundle="org.glassfish.admingui.community-theme.Strings");
+/>
+
 <sun:masthead id="Masthead" productImageURL="#{request.contextPath}/resource/community-theme/images/masthead-product_name_open.png" 
               style="border-width: 0px"
               productImageDescription="$resource{theme.productName}"


### PR DESCRIPTION
As identified by the OAG toolbar, for one of the image it was wrongly printing the "key" instead of its message as description.
The below fix resolves the issue.
Test: Ran the admingui devtests successfully.