### PR TITLE
Removing redundant labels from Admin Console 

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/availability/availabilityService.jsf
+++ b/appserver/admingui/cluster/src/main/resources/availability/availabilityService.jsf
@@ -85,7 +85,7 @@
 #include "/common/shared/configNameSection.inc"
             <sun:propertySheetSection id="propertSectionTextField">
                 <sun:property id="AvailabilityEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.availability.availabilityService}" helpText="$resource{i18ncs.availability.availabilityServiceHelp}">
-                     <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true"/>
+                     <sun:checkbox  selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true"/>
                  </sun:property>
                 "<br /><br />
             </sun:propertySheetSection>

--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterGeneral.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterGeneral.jsf
@@ -166,7 +166,7 @@
             </sun:property>
 
             <sun:property id="gmsEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.cluster.GMS}" helpText="$resource{i18ncs.cluster.GMSHelp}">
-                <sun:checkbox id="gmscb" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['gmsEnabled']}" selectedValue="true" />
+                <sun:checkbox id="gmscb"  selected="#{pageSession.valueMap['gmsEnabled']}" selectedValue="true" />
             </sun:property>
 
            <sun:property id="gmsMulticastPort"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.cluster.gmsMulticastPort}" helpText="$resource{i18ncs.cluster.gmsMulticastPortHelp}">

--- a/appserver/admingui/cluster/src/main/resources/node/nodeAttr.inc
+++ b/appserver/admingui/cluster/src/main/resources/node/nodeAttr.inc
@@ -181,7 +181,7 @@
                 <!afterCreate
                     getClientId(component="$this{component}" clientId="#{pageSession.installProp}");
                 />
-                <sun:checkbox id="installOption" selected="#{pageSession.valueMap['install']}" selectedValue="true"  label="Enabled" >
+                <sun:checkbox id="installOption" selected="#{pageSession.valueMap['install']}" selectedValue="true" >
                     <!afterCreate
                         getClientId(component="$this{component}" clientId="#{pageSession.installOptionId}");
                     />

--- a/appserver/admingui/cluster/src/main/resources/node/nodeAttr.inc
+++ b/appserver/admingui/cluster/src/main/resources/node/nodeAttr.inc
@@ -195,7 +195,7 @@
                 getClientId(component="$this{component}" clientId="#{pageSession.sshConnectorSectionId}");
             />
             <sun:property id="force"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.node.force}" helpText="$resource{i18ncs.node.forceHelp}">
-                <sun:checkbox id="force" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['force']}" selectedValue="true" />
+                <sun:checkbox id="force"  selected="#{pageSession.valueMap['force']}" selectedValue="true" />
             </sun:property>
             <sun:property id="sshport"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.node.sshPort}" helpText="$resource{i18ncs.node.sshPortHelp}">
                 <sun:textField id="sshport" text="#{pageSession.valueMap['sshport']}" columns="$int{60}" maxLength="#{sessionScope.fieldLengths['maxLength.node.sshPort']}"  />
@@ -244,7 +244,7 @@
                     <!afterCreate
                         getClientId(component="$this{component}" clientId="#{pageSession.setupSshPropId}");
                     />
-                <sun:checkbox id="setupSsh"  selected="#{pageSession.valueMap['setupSsh']}" label="$resource{i18n.common.Enabled}" selectedValue="true"
+                <sun:checkbox id="setupSsh"  selected="#{pageSession.valueMap['setupSsh']}"  selectedValue="true"
                       onChange="showSetupSSH();">
                     <!afterCreate
                         getClientId(component="$this{component}" clientId="#{pageSession.setupSshId}");
@@ -257,7 +257,7 @@
                 <!afterCreate
                     getClientId(component="$this{component}" clientId="#{pageSession.generateId}");
                 />
-                <sun:checkbox id="generate"  selected="#{pageSession.valueMap['generatekey']}" label="$resource{i18n.common.Enabled}" selectedValue="true" />
+                <sun:checkbox id="generate"  selected="#{pageSession.valueMap['generatekey']}"  selectedValue="true" />
             </sun:property>
 
             <sun:property id="setupPswd"   visible="#{pageSession.showSetupPswd}"   labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.node.setupsshPswd}" helpText="$resource{i18ncs.node.setupsshPswdHelp}">
@@ -298,11 +298,11 @@
                 getClientId(component="$this{component}" clientId="#{pageSession.dcomSectionId}");
             />
             <sun:property id="force"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.node.force}" helpText="$resource{i18ncs.node.forceHelp}">
-                <sun:checkbox id="force" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['winForce']}" selectedValue="true" />
+                <sun:checkbox id="force"  selected="#{pageSession.valueMap['winForce']}" selectedValue="true" />
             </sun:property>
 
             <sun:property id="validate"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.node.validateDcom}" helpText="$resource{i18ncs.node.validateDcomHelp}">
-                <sun:checkbox id="validate"  selected="#{pageSession.valueMap['validateDcom']}" label="$resource{i18n.common.Enabled}" selectedValue="true"
+                <sun:checkbox id="validate"  selected="#{pageSession.valueMap['validateDcom']}"  selectedValue="true"
                       onChange="showTestDir('#{pageSession.validateId}', '#{pageSession.testdirId}');">
                     <!afterCreate
                         getClientId(component="$this{component}" clientId="#{pageSession.validateId}");

--- a/appserver/admingui/common/src/main/resources/appServer/serverInstAppsConfig.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/serverInstAppsConfig.jsf
@@ -88,7 +88,7 @@
     <!-- Text Field section -->
     <sun:propertySheetSection id="propertSectionTextField">
       <sun:property id="reloadProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.Reload}" helpText="$resource{i18nc.domain.ReloadHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['dynamicReloadEnabled']}" selectedValue="true" >
+            <sun:checkbox  selected="#{pageSession.valueMap['dynamicReloadEnabled']}" selectedValue="true" >
             </sun:checkbox>
         </sun:property>
         <sun:property id="reloadIntervalProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.ReloadPollInterval}" helpText="$resource{i18nc.domain.ReloadPollIntervalHelp}">
@@ -104,7 +104,7 @@
     </sun:propertySheetSection>
     <sun:propertySheetSection id="propertSectionAutoDeploy" label="$resource{i18nc.domain.AutoDeploySettings}" >
         <sun:property id="AutoDeployProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.AutoDeploy}" helpText="$resource{i18nc.domain.AutoDeployHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['autodeployEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['autodeployEnabled']}" selectedValue="true" />
         </sun:property>
        <sun:property id="AutoDeployIntervalProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.AutoDeployPollInterval}" helpText="$resource{i18nc.domain.AutoDeployPollIntervalHelp}">
             <sun:textField id="AutoDeployInterval" styleClass="integer" columns="$int{15}" maxLength="#{sessionScope.fieldLengths['maxLength.domain.AutoDeployPollInterval']}" text="#{pageSession.valueMap['autodeployPollingIntervalInSeconds']}" />
@@ -121,10 +121,10 @@
                     <sun:dropDown id="trans" selected="#{pageSession.valueMap['deployXmlValidation']}" labels={"$resource{i18nc.domain.Full}" "$resource{i18nc.domain.Parsing}"  "$resource{i18nc.domain.None}"}  values={"full" "parsing"  "none"} />
                 </sun:property>
         <sun:property id="VerifierProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.Verifier}" helpText="$resource{i18nc.domain.VerifierHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['autodeployVerifierEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['autodeployVerifierEnabled']}" selectedValue="true" />
         </sun:property>
          <sun:property id="PrecompileProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.Precompile}" helpText="$resource{i18nc.domain.PrecompileHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['autodeployJspPrecompilationEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['autodeployJspPrecompilationEnabled']}" selectedValue="true" />
         </sun:property>
     "<br /><br />
     </sun:propertySheetSection>

--- a/appserver/admingui/common/src/main/resources/appServer/serverInstDomainAttrs.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/serverInstDomainAttrs.jsf
@@ -106,7 +106,7 @@
         
         <sun:property id="loadOnStartup"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}"
                       label="$resource{i18nc.domain.loadOnStartup}"  helpText="$resource{i18nc.domain.loadOnStartupHelp}">
-            <sun:checkbox  label="$resource{i18n.common.Enabled}" selected="#{pageSession.loadOnStartup}" selectedValue="true"  >
+            <sun:checkbox   selected="#{pageSession.loadOnStartup}" selectedValue="true"  >
                 <!beforeCreate
                     setPageSessionAttribute(key="loadOnStartup" value="false");
                     setPageSessionAttribute(key="origLoadOnStartup" value="false");

--- a/appserver/admingui/common/src/main/resources/applications/deploymentOtherFields.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/deploymentOtherFields.jsf
@@ -65,7 +65,7 @@
 </sun:property>
 
 <sun:property id="enableProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.status}"  helpText="$resource{i18n.deploy.statusHelp}">
-	<sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.other['enabled']}" selectedValue="true" >
+	<sun:checkbox  selected="#{pageSession.other['enabled']}" selectedValue="true" >
         <!beforeCreate
             mapPut(map="#{pageSession.other}", key="enabled", value="true" );
         />
@@ -73,11 +73,11 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.other['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.other['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="availability" rendered="#{!pageSession.onlyDASExist}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-    <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.other['availabilityEnabled']}" selectedValue="true" />
+    <sun:checkbox id="availability"  selected="#{pageSession.other['availabilityEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="osgi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.osgiType}" helpText="$resource{i18n.deploy.osgiTypeHelp}">

--- a/appserver/admingui/common/src/main/resources/applications/edit.inc
+++ b/appserver/admingui/common/src/main/resources/applications/edit.inc
@@ -50,7 +50,7 @@
         
 
         <sun:property id="statusProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox id="status" rendered="#{pageSession.onlyDASExist}" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox id="status" rendered="#{pageSession.onlyDASExist}"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
             <sun:staticText id="statusText" rendered="#{!pageSession.onlyDASExist}" text="#{pageSession.status}" />
         </sun:property>
 
@@ -87,16 +87,16 @@
         </sun:property>
 
         <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-            <sun:checkbox id="implicitCdi" disabled="true" label="$resource{i18n.common.Enabled}" selected="#{pageSession.implicitCdiEnabled}" selectedValue="true" />
+            <sun:checkbox id="implicitCdi" disabled="true"  selected="#{pageSession.implicitCdiEnabled}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="availability" rendered="#{pageSession.finalShowAvail}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-            <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
+            <sun:checkbox id="availability"  selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
         </sun:property>
 
 
         <sun:property id="jw" rendered="#{pageSession.showJavaWebStart}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.JavaWebStart}" helpText="$resource{i18n.edit.JavaWebStartHelp}">
-            <sun:checkbox id="jwc" disabled="true" label="$resource{i18n.common.Enabled}" selected="#{pageSession.javaWebStartEnabled}" selectedValue="true" >
+            <sun:checkbox id="jwc" disabled="true"  selected="#{pageSession.javaWebStartEnabled}" selectedValue="true" >
             </sun:checkbox>
         </sun:property>
 

--- a/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
@@ -55,7 +55,7 @@
         />
    </sun:radioButton>
     "<br />
-    <sun:upload id="fileupload" label="" style="margin-left: 17pt" columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.deploy.uploadedFile']}" uploadedFile="#{requestScope.uploadedFile}"
+    <sun:upload id="fileupload" style="margin-left: 17pt" columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.deploy.uploadedFile']}" uploadedFile="#{requestScope.uploadedFile}"
         onChange="javascript:admingui.deploy.setFieldValue('#{appNameId}', this.value,  '#{dropDownProp}', '#{typeId}', '#{contextRootId}', '#{extensionId}', window, '#{sessionScope.appTypeString}');">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{fileuploadId});

--- a/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
@@ -55,7 +55,7 @@
         />
    </sun:radioButton>
     "<br />
-    <sun:upload id="fileupload" style="margin-left: 17pt" columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.deploy.uploadedFile']}" uploadedFile="#{requestScope.uploadedFile}"
+    <sun:upload id="fileupload" label="" style="margin-left: 17pt" columns="$int{50}" maxLength="#{sessionScope.fieldLengths['maxLength.deploy.uploadedFile']}" uploadedFile="#{requestScope.uploadedFile}"
         onChange="javascript:admingui.deploy.setFieldValue('#{appNameId}', this.value,  '#{dropDownProp}', '#{typeId}', '#{contextRootId}', '#{extensionId}', window, '#{sessionScope.appTypeString}');">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{fileuploadId});

--- a/appserver/admingui/common/src/main/resources/applications/lifecycleAttr.inc
+++ b/appserver/admingui/common/src/main/resources/applications/lifecycleAttr.inc
@@ -71,11 +71,11 @@
     <!-- Virtual Server doesn't apply to lifecycle module. refer to issue# 13620 -->
 
     <sun:property id="statusNew" rendered="#{!edit}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-        <sun:checkbox id="status" label="$resource{i18n.common.Enabled}"  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+        <sun:checkbox id="status"   selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
     </sun:property>
 
     <sun:property id="statusEdit"  rendered="#{edit}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-        <sun:checkbox id="status" rendered="#{pageSession.onlyDASExist}" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+        <sun:checkbox id="status" rendered="#{pageSession.onlyDASExist}"  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
         <sun:staticText id="statusText" rendered="#{!pageSession.onlyDASExist}" text="#{pageSession.status}" />
     </sun:property>
 

--- a/appserver/admingui/common/src/main/resources/applications/redeployFrame.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/redeployFrame.jsf
@@ -143,19 +143,19 @@
                 <sun:staticText text="" />
             </sun:property>
             <sun:property id="precmplProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.precompile}" helpText="$resource{i18n.deploy.PrecompileHelp}">
-                <sun:checkbox id="precompileJSP" label="$resource{i18n.common.Enabled}" selected="#{pageSession.deployMap['precompilejsp']}" selectedValue="true" />
+                <sun:checkbox id="precompileJSP"  selected="#{pageSession.deployMap['precompilejsp']}" selectedValue="true" />
             </sun:property>
             <sun:property id="v2" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.run}" helpText="$resource{i18n.deploy.runHelp}">
-                    <sun:checkbox id="ver2" label="$resource{i18n.common.Enabled}" selected="#{pageSession.deployMap['verify']}" selectedValue="true" />
+                    <sun:checkbox id="ver2"  selected="#{pageSession.deployMap['verify']}" selectedValue="true" />
             </sun:property>
             <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-                <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.deployMap['implicitCdiEnabled']}" selectedValue="true" />
+                <sun:checkbox id="implicitCdi"  selected="#{pageSession.deployMap['implicitCdiEnabled']}" selectedValue="true" />
             </sun:property>
             <sun:property id="jws"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}"  label="$resource{i18n.deploy.JavaWebStart}" helpText="$resource{i18n.deploy.JavaWebStartHelp}" >
                 <sun:checkbox selected="#{pageSession.deployMap['$constant{org.glassfish.deployment.client.DFDeploymentProperties.DEPLOY_OPTION_JAVA_WEB_START_ENABLED}']}" selectedValue="true" label=" " />
             </sun:property>
             <sun:property id="availability" rendered="#{!pageSession.onlyDASExist}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-                <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.deployMap['availabilityEnabled']}" selectedValue="true" />
+                <sun:checkbox id="availability"  selected="#{pageSession.deployMap['availabilityEnabled']}" selectedValue="true" />
             </sun:property>
             <sun:property id="keepStateProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  label="$resource{i18n.redeploy.keepState}" helpText="$resource{i18n.redeploy.keepStateHelp}" >
                 <sun:checkbox selected="#{pageSession.deployMap['keepState']}" selectedValue="true" label=" " />

--- a/appserver/admingui/common/src/main/resources/configuration/jmxConnectorEdit.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/jmxConnectorEdit.jsf
@@ -99,7 +99,7 @@
                 />
             </sun:property>
             <sun:property id="SecurityProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.edJmxConnector.securityLabel}" >
-                <sun:checkbox id="Security" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+                <sun:checkbox id="Security"  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
             </sun:property>
             <sun:property id="AddressProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.edJmxConnector.addressLabel}" helpText="$resource{i18n.edJmxConnector.addressHelp}" >
                 <sun:textField id="Address" styleClass="required" columns="$int{40}" maxLength="#{sessionScope.fieldLengths['maxLength.edJmxConnector.address']}" text="#{pageSession.valueMap['address']}" required="#{true}" />

--- a/appserver/admingui/common/src/main/resources/configuration/loggerGeneral.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/loggerGeneral.jsf
@@ -109,19 +109,19 @@
 #include "/common/shared/configNameSection.inc"
     <sun:propertySheetSection id="sheetSection">
           <sun:property id="writeSystemLogEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.WriteSystemLog}" helpText="$resource{i18nc.log.WriteSystemlogHelp}">
-                <sun:checkbox id="writeSystemLogEnabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging']}" selectedValue="true" />
+                <sun:checkbox id="writeSystemLogEnabled"  selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging']}" selectedValue="true" />
            </sun:property> 
 
            <sun:property id="logtoConsole"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.LogtoConsole}" helpText="$resource{i18nc.log.LogtoConsoleHelp}">
-                <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.logtoConsole']}"  selectedValue="true" />
+                <sun:checkbox  selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.logtoConsole']}"  selectedValue="true" />
            </sun:property>
           
            <sun:property id="rotationOnDateChange"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.rotationOnDateChange}" helpText="$resource{i18nc.log.rotationOnDateChangeHelp}">
-                <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange']}"  selectedValue="true" />
+                <sun:checkbox  selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.rotationOnDateChange']}"  selectedValue="true" />
            </sun:property>
 
           <sun:property id="multiline"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.multiLineMode}" helpText="$resource{i18nc.log.multiLineModeHelp}">
-                <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.multiLineMode']}"  selectedValue="true" />
+                <sun:checkbox  selected="#{pageSession.logAttributes['com.sun.enterprise.server.logging.GFFileHandler.multiLineMode']}"  selectedValue="true" />
            </sun:property>
 
            <sun:property id="consoleFormat"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.log.ConsoleLogFormat}" helpText="$resource{i18nc.log.ConsoleLogFormatHelp}">

--- a/appserver/admingui/common/src/main/resources/javaConfig/jvmGeneral_2.inc
+++ b/appserver/admingui/common/src/main/resources/javaConfig/jvmGeneral_2.inc
@@ -60,7 +60,7 @@
                                 <sun:textField id="JavacOptions" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.jvm.JavacOptions']}" text="#{pageSession.valueMap['javacOptions']}"/>     
                             </sun:property>                        
                           <sun:property id="debugEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.jvm.DebugLabel}" helpText="$resource{i18nc.jvm.DebugHelp}">
-                                <sun:checkbox id="debug" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['debugEnabled']}" selectedValue="true" />      
+                                <sun:checkbox id="debug"  selected="#{pageSession.valueMap['debugEnabled']}" selectedValue="true" />      
                             </sun:property>
                             <sun:property id="DebugOptionsProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.jvm.DebugOptionsLabel}" helpText="$resource{i18nc.jvm.DebugOptionsHelp}">
                                 <sun:textField id="DebugOptions" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.jvm.DebugOptions']}" text="#{pageSession.valueMap['debugOptions']}" />      

--- a/appserver/admingui/common/src/main/resources/javaConfig/jvmProfiler_2.inc
+++ b/appserver/admingui/common/src/main/resources/javaConfig/jvmProfiler_2.inc
@@ -122,7 +122,7 @@
                     <sun:staticText id="ProfilerName2" text="#{pageSession.valueMap['name']}"/>
                 </sun:property>
                <sun:property id="profilerEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-                    <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+                    <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
                </sun:property>
                 <sun:property id="ClasspathProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.jvm.Classpath}" helpText="$resource{i18nc.jvm.ClasspathHelp}">
                     <sun:textField id="ClasspathLabel" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.jvm.Classpath']}"  text="#{pageSession.valueMap['classpath']}" />

--- a/appserver/admingui/common/src/main/resources/monitor/monitoringPage.jsf
+++ b/appserver/admingui/common/src/main/resources/monitor/monitoringPage.jsf
@@ -93,10 +93,10 @@
         />
 
         <sun:property id="monServiceProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.monService}"  helpText="$resource{common.monitoring.monServiceHelp}">
-            <sun:checkbox id="momServiceCheckbox"  label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['monitoringEnabled']}" selectedValue="true" />
+            <sun:checkbox id="momServiceCheckbox"   selected="#{pageSession.valueMap['monitoringEnabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="monMbeansProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{common.monitoring.monMbeans}"  helpText="$resource{common.monitoring.monMbeansHelp}">
-            <sun:checkbox id="momBbeanCheckbox" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['mbeanEnabled']}" selectedValue="true" />
+            <sun:checkbox id="momBbeanCheckbox"  selected="#{pageSession.valueMap['mbeanEnabled']}" selectedValue="true" />
         </sun:property>
         "<br />
     </sun:propertySheetSection>

--- a/appserver/admingui/common/src/main/resources/security/securityAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/security/securityAttrs.inc
@@ -47,7 +47,7 @@
     <!-- Text Field section -->
     <sun:propertySheetSection id="propertSectionTextField">
         <sun:property id="securityManagerProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.security.SecurityManager}"  helpText="$resource{i18nc.security.SecurityManagerHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.securityManagerStatus}" selectedValue="true"  >
+            <sun:checkbox  selected="#{pageSession.securityManagerStatus}" selectedValue="true"  >
             <!beforeCreate
                 setPageSessionAttribute(key="jvmOptionsUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/java-config/jvm-options");
                 getSecurityManagerValue(endpoint="#{pageSession.jvmOptionsUrl}" value="#{pageSession.securityManagerStatus}")
@@ -55,7 +55,7 @@
             </sun:checkbox>
         </sun:property>
         <sun:property id="auditLoggingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.security.AuditLogging}" helpText="$resource{i18nc.security.AuditLoggingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['auditEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['auditEnabled']}" selectedValue="true" />
         </sun:property>
 
       <sun:property id="defaultRealmProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.security.DefaultRealm}" helpText="$resource{i18nc.security.DefaultRealmHelp}">
@@ -95,7 +95,7 @@
             </sun:listbox>
         </sun:property>
        <sun:property id="roleMappingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.security.RoleMapping}" helpText="$resource{i18nc.security.RoleMappingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['activateDefaultPrincipalToRoleMapping']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['activateDefaultPrincipalToRoleMapping']}" selectedValue="true" />
         </sun:property>
         <sun:property id="mappedPrincipalClassProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.security.MappedPrincipalClass}" helpText="$resource{i18nc.security.MappedPrincipalClassHelp}">
             <sun:textField id="MappedPrincipalClass" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.security.MappedPrincipalClass']}" text="#{pageSession.valueMap['mappedPrincipalClass']}"/>

--- a/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/shared/sslAttrs.inc
@@ -65,7 +65,7 @@
      />
      
      <sun:property id="SSL3Prop"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.ssl3Label}" >
-        <sun:checkbox id="SSL3" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['ssl3Enabled']}" selectedValue="true" />
+        <sun:checkbox id="SSL3"  selected="#{pageSession.valueMap['ssl3Enabled']}" selectedValue="true" />
      </sun:property>
      <!--
      <sun:property id="SSL2Prop"  rendered="#{ssl2}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.ssl2Label}" >
@@ -73,11 +73,11 @@
      </sun:property>
      -->
      <sun:property id="TLSProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.tlsLabel}" >
-        <sun:checkbox id="TLS" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['tlsEnabled']}" selectedValue="true"/>
+        <sun:checkbox id="TLS"  selected="#{pageSession.valueMap['tlsEnabled']}" selectedValue="true"/>
      </sun:property>
 
      <sun:property id="ClientAuthProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.clientAuthLabel}" helpText="$resource{i18n.ssl.clientAuthHelp}" >
-        <sun:checkbox id="ClientAuth" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['clientAuthEnabled']}" selectedValue="true" />
+        <sun:checkbox id="ClientAuth"  selected="#{pageSession.valueMap['clientAuthEnabled']}" selectedValue="true" />
      </sun:property>
      <sun:property id="CertNicknameProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.ssl.certNicknameLabel}" helpText="$resource{i18n.ssl.certNicknameHelp}" >
         <sun:textField id="CertNickname" styleClass="required" required="#{true}" columns="$int{20}" maxLength="#{sessionScope.fieldLengths['maxLength.ssl.certNickname']}" text="#{pageSession.valueMap['certNickname']}" />

--- a/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
+++ b/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
@@ -41,7 +41,7 @@
 -->
 
 <sun:property id="ctxInfoEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.contextInfoLabel}">
-            <sun:checkbox id="ctxInfoEnabled"  label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['contextInfoEnabled']}" selectedValue="true"
+            <sun:checkbox id="ctxInfoEnabled"   selected="#{pageSession.valueMap['contextInfoEnabled']}" selectedValue="true"
                  //onChange="javascript:   webui.suntheme.dropDown.setDisabled('#{pageSession.ctxInfoCompId}', !this.checked); "
              />
         </sun:property>

--- a/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
+++ b/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
@@ -45,7 +45,7 @@
                  //onChange="javascript:   webui.suntheme.dropDown.setDisabled('#{pageSession.ctxInfoCompId}', !this.checked); "
              />
         </sun:property>
-        <sun:property id="contextInfo"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  helpText="$resource{i18ncon.contextInfoLabelHelp}">
+        <sun:property id="contextInfo"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  label="" helpText="$resource{i18ncon.contextInfoLabelHelp}">
             ### the beforeEncode is needed for 'loadDefault' since beforeCreate will not be called.
             <event>
                 <!beforeEncode

--- a/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
+++ b/appserver/admingui/concurrent/src/main/resources/contextInfo.inc
@@ -45,7 +45,7 @@
                  //onChange="javascript:   webui.suntheme.dropDown.setDisabled('#{pageSession.ctxInfoCompId}', !this.checked); "
              />
         </sun:property>
-        <sun:property id="contextInfo"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  label="" helpText="$resource{i18ncon.contextInfoLabelHelp}">
+        <sun:property id="contextInfo"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  helpText="$resource{i18ncon.contextInfoLabelHelp}">
             ### the beforeEncode is needed for 'loadDefault' since beforeCreate will not be called.
             <event>
                 <!beforeEncode

--- a/appserver/admingui/concurrent/src/main/resources/contextServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/contextServiceAttr.inc
@@ -75,8 +75,8 @@
         </sun:property>
 
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/concurrent/src/main/resources/contextServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/contextServiceAttr.inc
@@ -75,7 +75,6 @@
         </sun:property>
 
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
@@ -65,7 +65,6 @@
 
 #include "/concurrent/contextInfo.inc"
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
@@ -65,8 +65,8 @@
 
 #include "/concurrent/contextInfo.inc"
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">
@@ -82,7 +82,7 @@
        </sun:property>
        
        <sun:property id="longrunningtasks"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.longRunningTasks}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['longRunningTasks']}" selectedValue="true"  />
+            <sun:checkbox  selected="#{pageSession.valueMap['longRunningTasks']}" selectedValue="true"  />
        </sun:property>
        
        <sun:property id="hungafter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.hungAfterSeconds}"  helpText="$resource{i18ncon.hungAfterSecondsHelp}">

--- a/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
@@ -67,7 +67,6 @@
 
 #include "/concurrent/contextInfo.inc"
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
@@ -67,8 +67,8 @@
 
 #include "/concurrent/contextInfo.inc"
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/corba/src/main/resources/iiopListenerAttrs.inc
+++ b/appserver/admingui/corba/src/main/resources/iiopListenerAttrs.inc
@@ -59,10 +59,10 @@
             <sun:textField id="ListenerPort" styleClass="required port" columns="$int{20}" maxLength="#{sessionScope.fieldLengths['maxLength.iiopListener.listPort']}" text="#{pageSession.valueMap['port']}" required="#{true}" />
         </sun:property>
         <sun:property id="ListenerProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_corba.iiopListener.listenerLabel}" helpText="$resource{i18n_corba.iiopListener.listenerHelp}" >
-            <sun:checkbox label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="SecurityProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_corba.iiopListener.securityEnable}" >
-            <sun:checkbox id="Security" label="$resource{i18n.desc.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox id="Security"  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
     </sun:propertySheetSection>
 </sun:propertySheet>    

--- a/appserver/admingui/ejb/src/main/resources/configuration/ejbAvailabilityService.jsf
+++ b/appserver/admingui/ejb/src/main/resources/configuration/ejbAvailabilityService.jsf
@@ -84,7 +84,7 @@
 #include "/common/shared/configNameSection.inc"
             <sun:propertySheetSection id="propertSectionTextField">
                 <sun:property id="AvailabilityEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.availability.availabilityService}" helpText="$resource{i18n_ejb.availability.ejbAvailabilityServiceHelp}">
-                    <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
+                    <sun:checkbox  selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
                 </sun:property>
                 <sun:property id="HAPersistenceTypeProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_ejb.availability.haPersistenceType}" helpText="$resource{i18n_ejb.availability.haPersistenceTypeHelp}">
                     <sun:dropDown id="HAPersistenceType" selected="#{pageSession.valueMap['sfsbHaPersistenceType']}" labels="#{pageSession.persistenceType}">

--- a/appserver/admingui/full/src/main/resources/apps/deploymentAppClient.jsf
+++ b/appserver/admingui/full/src/main/resources/apps/deploymentAppClient.jsf
@@ -67,11 +67,11 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.appClient['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.appClient['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="jw" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.JavaWebStart}" helpText="$resource{i18n.deploy.JavaWebStartHelp}">
-	<sun:checkbox id="jwt" label="$resource{i18n.common.Enabled}" selected="#{pageSession.appClient['PROPERTY-$constant{org.glassfish.deployment.client.DFDeploymentProperties.DEPLOY_OPTION_JAVA_WEB_START_ENABLED}']}" selectedValue="true" />
+	<sun:checkbox id="jwt"  selected="#{pageSession.appClient['PROPERTY-$constant{org.glassfish.deployment.client.DFDeploymentProperties.DEPLOY_OPTION_JAVA_WEB_START_ENABLED}']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="v2" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.run}" helpText="$resource{i18n.deploy.runHelp}">

--- a/appserver/admingui/full/src/main/resources/apps/deploymentEarFields.jsf
+++ b/appserver/admingui/full/src/main/resources/apps/deploymentEarFields.jsf
@@ -68,7 +68,7 @@
 </sun:property>
 
 <sun:property id="enableProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.status}"  helpText="$resource{i18n.deploy.statusHelp}">
-	<sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.ear['enabled']}" selectedValue="true" >
+	<sun:checkbox  selected="#{pageSession.ear['enabled']}" selectedValue="true" >
         <!beforeCreate
             mapPut(map="#{pageSession.ear}", key="enabled", value="true" );
         />
@@ -76,15 +76,15 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ear['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.ear['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="availability"  rendered="#{!pageSession.onlyDASExist}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-    <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ear['availabilityEnabled']}" selectedValue="true" />
+    <sun:checkbox id="availability"  selected="#{pageSession.ear['availabilityEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="jw" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.JavaWebStart}" helpText="$resource{i18n.deploy.JavaWebStartHelp}">
-	<sun:checkbox id="jwc" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ear['PROPERTY-$constant{org.glassfish.deployment.client.DFDeploymentProperties.DEPLOY_OPTION_JAVA_WEB_START_ENABLED}']}" selectedValue="true" />
+	<sun:checkbox id="jwc"  selected="#{pageSession.ear['PROPERTY-$constant{org.glassfish.deployment.client.DFDeploymentProperties.DEPLOY_OPTION_JAVA_WEB_START_ENABLED}']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="precmplProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.precompile}" helpText="$resource{i18n.deploy.PrecompileHelp}">

--- a/appserver/admingui/full/src/main/resources/apps/deploymentEjb.jsf
+++ b/appserver/admingui/full/src/main/resources/apps/deploymentEjb.jsf
@@ -68,7 +68,7 @@
 </sun:property>
 
 <sun:property id="enableProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.status}"  helpText="$resource{i18n.deploy.statusHelp}">
-	<sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.ejb['enabled']}" selectedValue="true" >
+	<sun:checkbox  selected="#{pageSession.ejb['enabled']}" selectedValue="true" >
         <!beforeCreate
             mapPut(map="#{pageSession.ejb}", key="enabled", value="true" );
         />
@@ -76,15 +76,15 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ejb['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.ejb['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="availability"  rendered="#{!pageSession.onlyDASExist}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-    <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ejb['availabilityEnabled']}" selectedValue="true" />
+    <sun:checkbox id="availability"  selected="#{pageSession.ejb['availabilityEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="v2" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.run}" helpText="$resource{i18n.deploy.runHelp}">
-        <sun:checkbox id="ver2" label="$resource{i18n.common.Enabled}" selected="#{pageSession.ejb['verify']}" selectedValue="true" />
+        <sun:checkbox id="ver2"  selected="#{pageSession.ejb['verify']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="compatibility" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.compatibility}" helpText="$resource{i18n.deploy.compatibilityHelp}">

--- a/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
+++ b/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
@@ -115,8 +115,8 @@
         </sun:property>
 
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
             <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{statusId});
             />

--- a/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
+++ b/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
@@ -64,7 +64,7 @@
                     onClick="enableClassnameFields('predefine'); updateFactoryClassOnClick();"
                 />
                 <sun:dropDown id="Classname" labels="$pageSession{builtInEntries}"  values="$pageSession{builtInEntries}"  selected="#{attrMap.classname}"
-                    disabled="#{!attrMap.predefinedClassname}" onChange="updateFactoryClass(this.value);" label="" >
+                    disabled="#{!attrMap.predefinedClassname}" onChange="updateFactoryClass(this.value);" >
                     <!afterCreate
                         getClientId(component="$this{component}" clientId=>$page{classnameDropdownId});
                     />
@@ -74,9 +74,9 @@
                 "<br /><br />
 
                 <sun:radioButton id="optB"  name="classnameOption" selected="$pageSession{classnameOption}" selectedValue="input"
-                    onClick="javascript: enableClassnameFields('input');" label=""
+                    onClick="javascript: enableClassnameFields('input');"
                 />
-                <sun:textField id="ClassnameText" text="#{attrMap.classnameInput}" columns="$int{70}" maxLength="#{sessionScope.fieldLengths['maxLength.jndiResource.className']}" label="" >
+                <sun:textField id="ClassnameText" text="#{attrMap.classnameInput}" columns="$int{70}" maxLength="#{sessionScope.fieldLengths['maxLength.jndiResource.className']}">
                     <!afterCreate
                         getClientId(component="$this{component}" clientId=>$page{classnameTextId});
                     />

--- a/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
+++ b/appserver/admingui/full/src/main/resources/jndiResourceAttr.inc
@@ -64,7 +64,7 @@
                     onClick="enableClassnameFields('predefine'); updateFactoryClassOnClick();"
                 />
                 <sun:dropDown id="Classname" labels="$pageSession{builtInEntries}"  values="$pageSession{builtInEntries}"  selected="#{attrMap.classname}"
-                    disabled="#{!attrMap.predefinedClassname}" onChange="updateFactoryClass(this.value);" >
+                    disabled="#{!attrMap.predefinedClassname}" onChange="updateFactoryClass(this.value);" label="" >
                     <!afterCreate
                         getClientId(component="$this{component}" clientId=>$page{classnameDropdownId});
                     />
@@ -74,9 +74,9 @@
                 "<br /><br />
 
                 <sun:radioButton id="optB"  name="classnameOption" selected="$pageSession{classnameOption}" selectedValue="input"
-                    onClick="javascript: enableClassnameFields('input');"
+                    onClick="javascript: enableClassnameFields('input');" label=""
                 />
-                <sun:textField id="ClassnameText" text="#{attrMap.classnameInput}" columns="$int{70}" maxLength="#{sessionScope.fieldLengths['maxLength.jndiResource.className']}">
+                <sun:textField id="ClassnameText" text="#{attrMap.classnameInput}" columns="$int{70}" maxLength="#{sessionScope.fieldLengths['maxLength.jndiResource.className']}" label="" >
                     <!afterCreate
                         getClientId(component="$this{component}" clientId=>$page{classnameTextId});
                     />
@@ -115,7 +115,6 @@
         </sun:property>
 
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
             <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{statusId});

--- a/appserver/admingui/full/src/main/resources/mailResourceAttr.inc
+++ b/appserver/admingui/full/src/main/resources/mailResourceAttr.inc
@@ -78,7 +78,6 @@
         </sun:property>
 
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
        </sun:property>
        <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/full/src/main/resources/mailResourceAttr.inc
+++ b/appserver/admingui/full/src/main/resources/mailResourceAttr.inc
@@ -78,8 +78,8 @@
         </sun:property>
 
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
        </sun:property>
        <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">
@@ -111,7 +111,7 @@
         </sun:property>
 
         <sun:property id="debugProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njmail.javaMail.Debug}"  helpText="$resource{i18njmail.javaMail.DebugHelp}">
-            <sun:checkbox selected="#{pageSession.valueMap['debug']}"  label="$resource{i18n.common.Enabled}" selectedValue="true" />
+            <sun:checkbox selected="#{pageSession.valueMap['debug']}"   selectedValue="true" />
        </sun:property>   
         "<br /><br />
     </sun:propertySheetSection>

--- a/appserver/admingui/jca/src/main/resources/adminObjectAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/adminObjectAttr.inc
@@ -184,7 +184,6 @@
             </sun:textField>
         </sun:property>
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}" >
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
                 <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{statusId});                    

--- a/appserver/admingui/jca/src/main/resources/adminObjectAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/adminObjectAttr.inc
@@ -184,8 +184,8 @@
             </sun:textField>
         </sun:property>
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" >
                 <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{statusId});                    
                 />

--- a/appserver/admingui/jca/src/main/resources/apps/deploymentRar.jsf
+++ b/appserver/admingui/jca/src/main/resources/apps/deploymentRar.jsf
@@ -66,7 +66,7 @@
     </sun:textField>
 </sun:property>
 <sun:property id="enableProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.status}"  helpText="$resource{i18n.deploy.statusHelp}">
-	<sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.rar['enabled']}" selectedValue="true" >
+	<sun:checkbox  selected="#{pageSession.rar['enabled']}" selectedValue="true" >
         <!beforeCreate
             mapPut(map="#{pageSession.rar}", key="enabled", value="true" );
         />
@@ -74,7 +74,7 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.rar['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.rar['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="v2" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.run}" helpText="$resource{i18n.deploy.runHelp}">

--- a/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAdvancedAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAdvancedAttr.inc
@@ -76,11 +76,11 @@
    </sun:property>
 
    <sun:property id="poolingProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.pooling}" helpText="$resource{i18njca.jcaPool.poolingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['pooling']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['pooling']}" selectedValue="true" />
        </sun:property>
 
     <sun:property id="p7"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.lazyConnectionAssociation}" helpText="$resource{i18njca.jcaPool.lazyConnectionAssociationHelp}">
-        <sun:checkbox id="associate"  selected="#{pageSession.valueMap['lazyConnectionAssociation']}" label="$resource{i18n.common.Enabled}" onClick="enableDisableLazyConnection('#{associateId}');" selectedValue="true" >  
+        <sun:checkbox id="associate"  selected="#{pageSession.valueMap['lazyConnectionAssociation']}"  onClick="enableDisableLazyConnection('#{associateId}');" selectedValue="true" >  
            <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{associateId});
             />
@@ -88,7 +88,7 @@
    </sun:property>
 
     <sun:property id="p6"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.lazyConnectionEnlistment}" helpText="$resource{i18njca.jcaPool.lazyConnectionEnlistmentHelp}">
-        <sun:checkbox id="enlist"  selected="#{pageSession.valueMap['lazyConnectionEnlistment']}" label="$resource{i18n.common.Enabled}"  selectedValue="true">  
+        <sun:checkbox id="enlist"  selected="#{pageSession.valueMap['lazyConnectionEnlistment']}"   selectedValue="true">  
             <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{enlistId});
             />
@@ -96,11 +96,11 @@
     </sun:property>
 
     <sun:property id="p8"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.associationWithThread}" helpText="$resource{i18njca.jcaPool.associationWithThreadHelp}">
-        <sun:checkbox  selected="#{pageSession.valueMap['associateWithThread']}" label="$resource{i18n.common.Enabled}" selectedValue="true"/>  
+        <sun:checkbox  selected="#{pageSession.valueMap['associateWithThread']}"  selectedValue="true"/>  
    </sun:property>
 
     <sun:property id="p9"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.matchConnections}" helpText="$resource{i18njca.jcaPool.matchConnectionsHelp}">
-        <sun:checkbox  selected="#{pageSession.valueMap['matchConnections']}" label="$resource{i18n.common.Enabled}" selectedValue="true"/>  
+        <sun:checkbox  selected="#{pageSession.valueMap['matchConnections']}"  selectedValue="true"/>  
    </sun:property>
 
     <sun:property id="p10"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.maxConnectionUsageCount}" helpText="$resource{i18njca.jcaPool.maxConnectionUsageCountHelp}">

--- a/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAttr.inc
@@ -61,7 +61,7 @@
         </sun:property>
 
         <sun:property id="pingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.ping}" helpText="$resource{i18njca.jcaPool.pingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{sessionScope.wizardMap.ping}" selectedValue="true" />
+            <sun:checkbox  selected="#{sessionScope.wizardMap.ping}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="descProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18n.common.description}" >

--- a/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAttrEdit.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAttrEdit.inc
@@ -76,7 +76,7 @@
         </sun:property>
 
         <sun:property id="pingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njca.jcaPool.ping}" helpText="$resource{i18njca.jcaPool.pingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap.ping}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap.ping}" selectedValue="true" />
         </sun:property>
         <sun:property id="deploymentOrder" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.resource.deploymentOrder}"  helpText="$resource{i18n.common.resource.deploymentOrderHelp}">
             <sun:textField id="deploymentOrder" styleClass="integer" columns="$int{10}" maxLength="#{sessionScope.fieldLengths['maxLength.common.deploymentOrder']}" text="#{pageSession.valueMap.deploymentOrder}" />

--- a/appserver/admingui/jca/src/main/resources/connectorResourceAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorResourceAttr.inc
@@ -74,7 +74,6 @@
             <sun:textField id="desc" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['description']}" />      
         </sun:property>
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/jca/src/main/resources/connectorResourceAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorResourceAttr.inc
@@ -74,8 +74,8 @@
             <sun:textField id="desc" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['description']}" />      
         </sun:property>
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/jca/src/main/resources/workSecurityMapAttr.inc
+++ b/appserver/admingui/jca/src/main/resources/workSecurityMapAttr.inc
@@ -116,7 +116,7 @@
             <sun:textField id="descAdaptor" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['description']}" />
         </sun:property>
         <!--<sun:property id="status"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
        </sun:property>-->
 
 </sun:propertySheetSection>

--- a/appserver/admingui/jdbc/src/main/resources/advancePool.inc
+++ b/appserver/admingui/jdbc/src/main/resources/advancePool.inc
@@ -73,10 +73,10 @@
             </sun:textField>
         </sun:property>
          <sun:property id="p1"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.wrapJdbcObjects}" helpText="$resource{i18njdbc.jdbcPool.wrapJdbcObjectsHelp}">
-            <sun:checkbox  selected="#{pageSession.valueMap['wrapJdbcObjects']}" label="$resource{i18n.common.Enabled}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['wrapJdbcObjects']}"  selectedValue="true" />
        </sun:property>
        <sun:property id="poolingProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.pooling}" helpText="$resource{i18njdbc.jdbcPool.poolingHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['pooling']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['pooling']}" selectedValue="true" />
        </sun:property>
 </sun:propertySheetSection>
 <sun:propertySheetSection id="connectionPropertySheet" label="$resource{i18njdbc.jdbcPool.connectionSettings}">
@@ -114,7 +114,7 @@
    </sun:property>
 
     <sun:property id="p7"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.lazyConnectionAssociation}" helpText="$resource{i18njdbc.jdbcPool.lazyConnectionAssociationHelp}">
-        <sun:checkbox id="associate"  selected="#{pageSession.valueMap['lazyConnectionAssociation']}" label="$resource{i18n.common.Enabled}" onClick="enableDisableLazyConnection('#{associateId}');" selectedValue="true" >  
+        <sun:checkbox id="associate"  selected="#{pageSession.valueMap['lazyConnectionAssociation']}"  onClick="enableDisableLazyConnection('#{associateId}');" selectedValue="true" >  
            <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{associateId});
             />
@@ -122,7 +122,7 @@
    </sun:property>
 
     <sun:property id="p6"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.lazyConnectionEnlistment}" helpText="$resource{i18njdbc.jdbcPool.lazyConnectionEnlistmentHelp}">
-        <sun:checkbox id="enlist"  selected="#{pageSession.valueMap['lazyConnectionEnlistment']}" label="$resource{i18n.common.Enabled}"  selectedValue="true">  
+        <sun:checkbox id="enlist"  selected="#{pageSession.valueMap['lazyConnectionEnlistment']}"   selectedValue="true">  
             <!afterCreate
                     getClientId(component="$this{component}" clientId=>$page{enlistId});
             />
@@ -130,10 +130,10 @@
     </sun:property>
 
     <sun:property id="p8"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.associationWithThread}" helpText="$resource{i18njdbc.jdbcPool.associationWithThreadHelp}">
-        <sun:checkbox  selected="#{pageSession.valueMap['associateWithThread']}" label="$resource{i18n.common.Enabled}" selectedValue="true"/>  
+        <sun:checkbox  selected="#{pageSession.valueMap['associateWithThread']}"  selectedValue="true"/>  
    </sun:property>
    <sun:property id="p9"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.matchConnections}" helpText="$resource{i18njdbc.jdbcPool.matchConnectionsHelp}">
-        <sun:checkbox  selected="#{pageSession.valueMap['matchConnections']}" label="$resource{i18n.common.Enabled}" selectedValue="true"/>  
+        <sun:checkbox  selected="#{pageSession.valueMap['matchConnections']}"  selectedValue="true"/>  
    </sun:property>
 
     <sun:property id="p10"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.maxConnectionUsageCount}" helpText="$resource{i18njdbc.jdbcPool.maxConnectionUsageCountHelp}">
@@ -219,7 +219,7 @@
        </sun:property>
 
         <sun:property id="allowProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.allowCaller}" helpText="$resource{i18njdbc.jdbcPool.allowCallerHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap.allowNonComponentCallers}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap.allowNonComponentCallers}" selectedValue="true" />
        </sun:property>
 
       "<br /><br />

--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolNew1.jsf
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolNew1.jsf
@@ -117,7 +117,7 @@
                                 </sun:textField>
                             </sun:property>
                             <sun:property id="introspect"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.introspect}" helpText="$resource{i18njdbc.jdbcPool.introspectHelp}">
-                                <sun:checkbox  selected="#{wizardPoolExtra.introspect}" label="$resource{i18n.common.Enabled}" selectedValue="true" />
+                                <sun:checkbox  selected="#{wizardPoolExtra.introspect}"  selectedValue="true" />
                             </sun:property>
                             
                             "<br /><br />

--- a/appserver/admingui/jdbc/src/main/resources/jdbcResource.inc
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcResource.inc
@@ -84,7 +84,6 @@
         </sun:property>
 
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
             <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"

--- a/appserver/admingui/jdbc/src/main/resources/jdbcResource.inc
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcResource.inc
@@ -84,8 +84,8 @@
         </sun:property>
 
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
-            <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" visible="#{false}" />
+            <sun:checkbox id="enabled"  selected="#{pageSession.valueMap2['enabled']}" selectedValue="true" />
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/jdbc/src/main/resources/poolPropertyEdit.inc
+++ b/appserver/admingui/jdbc/src/main/resources/poolPropertyEdit.inc
@@ -75,7 +75,7 @@
         </sun:textField>
     </sun:property>
     <sun:property id="pingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.ping}" helpText="$resource{i18njdbc.jdbcPool.pingHelp}">
-        <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap.ping}" selectedValue="true" />
+        <sun:checkbox  selected="#{pageSession.valueMap.ping}" selectedValue="true" />
    </sun:property>
    <sun:property id="deploymentOrder" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.resource.deploymentOrder}"  helpText="$resource{i18n.common.resource.deploymentOrderHelp}" >
        <sun:textField id="deploymentOrder" styleClass="integer" columns="$int{10}" maxLength="#{sessionScope.fieldLengths['maxLength.common.deploymentOrder']}" text="#{pageSession.valueMap['deploymentOrder']}" />
@@ -122,7 +122,7 @@
 <sun:propertySheetSection id="transactionPropertySheet" label="$resource{i18njdbc.jdbcPool.transIsolationSection}">
 
     <sun:property id="nonTransProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.nonTransConnection}" helpText="$resource{i18njdbc.jdbcPool.nonTransConnectionHelp}">
-        <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{valueMap.nonTransactionalConnections}" selectedValue="true" />
+        <sun:checkbox  selected="#{valueMap.nonTransactionalConnections}" selectedValue="true" />
    </sun:property>
 
     <sun:property id="transProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.transIsolation}" helpText="$resource{i18njdbc.jdbcPool.transIsolationHelp}" >

--- a/appserver/admingui/jdbc/src/main/resources/poolPropertyNew.inc
+++ b/appserver/admingui/jdbc/src/main/resources/poolPropertyNew.inc
@@ -85,7 +85,7 @@
     </sun:property>
 
     <sun:property id="pingProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.ping}" helpText="$resource{i18njdbc.jdbcPool.pingHelp}">
-        <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{sessionScope.wizardMap.ping}" selectedValue="true" />
+        <sun:checkbox  selected="#{sessionScope.wizardMap.ping}" selectedValue="true" />
    </sun:property>
     <sun:property id="descProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18n.common.description}" >
         <sun:textField id="desc" columns="$int{60}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{sessionScope.wizardMap.Description}" />
@@ -130,7 +130,7 @@
 <sun:propertySheetSection id="transactionPropertySheet" label="$resource{i18njdbc.jdbcPool.transIsolationSection}">
 
     <sun:property id="nonTransProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.nonTransConnection}" helpText="$resource{i18njdbc.jdbcPool.nonTransConnectionHelp}">
-        <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{sessionScope.wizardMap.nonTransactionalConnections}" selectedValue="true" />
+        <sun:checkbox  selected="#{sessionScope.wizardMap.nonTransactionalConnections}" selectedValue="true" />
    </sun:property>
 
     <sun:property id="transProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.transIsolation}" helpText="$resource{i18njdbc.jdbcPool.transIsolationHelp}" >

--- a/appserver/admingui/jms-plugin/src/main/resources/jmsAvailabilityService.jsf
+++ b/appserver/admingui/jms-plugin/src/main/resources/jmsAvailabilityService.jsf
@@ -84,7 +84,7 @@
 #include "/common/shared/configNameSection.inc"
             <sun:propertySheetSection id="propertSectionTextField">
                 <sun:property id="AvailabilityEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.availability.availabilityService}" helpText="$resource{i18njms.availability.jmsAvailabilityInfoHelp}">
-                    <sun:checkbox id="avail" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
+                    <sun:checkbox id="avail"  selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
                 </sun:property>
                 <sun:property id="ConfigStoreTypeProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njms.availability.configStoreType}" helpText="$resource{i18njms.availability.configStoreTypeHelp}">
                     <sun:dropDown id="ConfigStoreType" selected="#{pageSession.valueMap['configStoreType']}" labels={"masterbroker" , "shareddb"} />

--- a/appserver/admingui/jms-plugin/src/main/resources/jmsDestinationSheet.inc
+++ b/appserver/admingui/jms-plugin/src/main/resources/jmsDestinationSheet.inc
@@ -78,7 +78,7 @@
         </sun:property>
 
         <sun:property id="statusProp"  rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox id="cb" label="$resource{i18n.common.Enabled}" immediate="#{true}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true"/>
+            <sun:checkbox id="cb"  immediate="#{true}" selected="#{pageSession.valueMap2['enabled']}" selectedValue="true"/>
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/jms-plugin/src/main/resources/jmsService.jsf
+++ b/appserver/admingui/jms-plugin/src/main/resources/jmsService.jsf
@@ -162,7 +162,7 @@
                                 <sun:textField id="Arguments" columns="$int{35}" maxLength="#{sessionScope.fieldLengths['maxLength.jms.Arguments']}" text="#{pageSession.valueMap['startArgs']}"/>
                             </sun:property>
                             <sun:property id="reconnectProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njms.jms.Reconnect}" helpText="$resource{i18njms.jms.ReconnectHelp}">
-                                <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['reconnectEnabled']}" selectedValue="true"/>
+                                <sun:checkbox  selected="#{pageSession.valueMap['reconnectEnabled']}" selectedValue="true"/>
                             </sun:property>
                             <sun:property id="intervalProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njms.jms.Interval}" helpText="$resource{i18njms.jms.IntervalHelp}">
                                 <sun:textField id="Interval" styleClass="intAllowMinusOne" columns="$int{10}" maxLength="#{sessionScope.fieldLengths['maxLength.jms.Interval']}" text="#{pageSession.valueMap['reconnectIntervalInSeconds']}" />

--- a/appserver/admingui/jms-plugin/src/main/resources/poolProperties.inc
+++ b/appserver/admingui/jms-plugin/src/main/resources/poolProperties.inc
@@ -71,7 +71,7 @@
             <sun:textField id="descProp" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['description']}" />
         </sun:property>
         <sun:property id="statusProp" rendered="#{useCheckBox}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.resourceRef['enabled']}" selectedValue="true"/>
+            <sun:checkbox  selected="#{pageSession.resourceRef['enabled']}" selectedValue="true"/>
         </sun:property>
         <sun:property id="statusProp2" rendered="#{useString}"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
             label="$resource{i18n.common.status}" helpText="$resource{i18n.application.EnableTargetHelp}">

--- a/appserver/admingui/jts/src/main/resources/transactionService.jsf
+++ b/appserver/admingui/jts/src/main/resources/transactionService.jsf
@@ -82,7 +82,7 @@
 #include "/common/shared/configNameSection.inc"
             <sun:propertySheetSection id="propertSectionTextField">
                 <sun:property id="onRestartProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_jts.ts.OnRestart}" helpText="$resource{i18n_jts.ts.OnRestartHelp}">
-                    <sun:checkbox id="enabled" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['automaticRecovery']}" selectedValue="true">
+                    <sun:checkbox id="enabled"  selected="#{pageSession.valueMap['automaticRecovery']}" selectedValue="true">
                    </sun:checkbox>
                 </sun:property>
                 <sun:property id="timeoutProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_jts.ts.Timeout}" helpText="$resource{i18n_jts.ts.TimeoutHelp}">

--- a/appserver/admingui/web/src/main/resources/apps/deploymentWarFields.jsf
+++ b/appserver/admingui/web/src/main/resources/apps/deploymentWarFields.jsf
@@ -68,7 +68,7 @@
 </sun:property>
 
 <sun:property id="enableProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.status}"  helpText="$resource{i18n.deploy.statusHelp}">
-	<sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.war['enabled']}" selectedValue="true" >
+	<sun:checkbox  selected="#{pageSession.war['enabled']}" selectedValue="true" >
         <!beforeCreate
             mapPut(map="#{pageSession.war}", key="enabled", value="true" );
         />
@@ -76,11 +76,11 @@
 </sun:property>
 
 <sun:property id="implicitCdi" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.implicitCdi}" helpText="$resource{i18n.deploy.implicitCdiHelp}">
-    <sun:checkbox id="implicitCdi" label="$resource{i18n.common.Enabled}" selected="#{pageSession.war['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
+    <sun:checkbox id="implicitCdi"  selected="#{pageSession.war['PROPERTY-implicitCdiEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="availability" rendered="#{!pageSession.onlyDASExist}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.availability}" helpText="$resource{i18n.deploy.availabilityHelp}">
-    <sun:checkbox id="availability" label="$resource{i18n.common.Enabled}" selected="#{pageSession.war['availabilityEnabled']}" selectedValue="true" />
+    <sun:checkbox id="availability"  selected="#{pageSession.war['availabilityEnabled']}" selectedValue="true" />
 </sun:property>
 
 <sun:property id="precmplProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.deploy.precompile}" helpText="$resource{i18n.deploy.PrecompileHelp}">

--- a/appserver/admingui/web/src/main/resources/configuration/accessLog.jsf
+++ b/appserver/admingui/web/src/main/resources/configuration/accessLog.jsf
@@ -89,18 +89,18 @@
 
         <sun:propertySheetSection id="http" >
             <sun:property id="acLog" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.access.SsoEnbaled}">
-                <sun:checkbox id="ssoEnabled" label="$resource{i18n.common.Enabled}"  selected="#{pageSession.valueMap['ssoEnabled']}" selectedValue="true"/>
+                <sun:checkbox id="ssoEnabled"   selected="#{pageSession.valueMap['ssoEnabled']}" selectedValue="true"/>
             </sun:property>
         </sun:propertySheetSection>
     
         <sun:propertySheetSection id="accessLog" label="$resource{i18n_web.access.SectionTitle}">
 
         <sun:property id="acLog" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.accessLogging}">
-            <sun:checkbox id="accessLoggingEnabled" label="$resource{i18n.common.Enabled}"  selected="#{pageSession.valueMap['accessLoggingEnabled']}" selectedValue="true"/>
+            <sun:checkbox id="accessLoggingEnabled"   selected="#{pageSession.valueMap['accessLoggingEnabled']}" selectedValue="true"/>
         </sun:property>
 
         <sun:property id="rotationProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.access.Rotation}" helpText="$resource{i18n_web.access.RotationHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['rotationEnabled']}" selectedValue="true" >
+            <sun:checkbox  selected="#{pageSession.valueMap2['rotationEnabled']}" selectedValue="true" >
            </sun:checkbox>
         </sun:property>
         <sun:property id="rotationPolicyProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.access.RotationPolicy}" helpText="$resource{i18n_web.access.RotationPolicyHelp}">

--- a/appserver/admingui/web/src/main/resources/configuration/httpListenerAttr.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/httpListenerAttr.inc
@@ -58,15 +58,15 @@
         </sun:property>
 
         <sun:property id="status"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.common.status}"  helpText="$resource{i18n_web.grizzly.networkListener.statusHelp}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="security"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.security}" helpText="#{pageSession.secHelpText}" >
-            <sun:checkbox disabled="#{readOnly}"  label="$resource{i18n.common.Enabled}" selected="#{pageSession.protocolMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox disabled="#{readOnly}"   selected="#{pageSession.protocolMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="JkEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.JkEnabled}" helpText="$resource{i18n_web.grizzly.networkListener.JkEnabledHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['jkEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['jkEnabled']}" selectedValue="true" />
         </sun:property>
         
         <sun:property id="addr"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.address}" helpText="$resource{i18n_web.grizzly.networkListener.addressHelp}">

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerAttrs.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerAttrs.inc
@@ -66,7 +66,7 @@
         </sun:property>
 
         <sun:property id="ssoCookieHttpOnly"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.ssoCookieHttpOnly}" helpText="$resource{i18n_web.vs.ssoCookieHttpOnlyHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['ssoCookieHttpOnly']}"  selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['ssoCookieHttpOnly']}"  selectedValue="true" />
         </sun:property>
 
         <sun:property id="nwProps"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.NetworkListeners}" helpText="$resource{i18n_web.vs.NetworkListenersHelp}">

--- a/appserver/admingui/web/src/main/resources/configuration/webAvailabilityService.jsf
+++ b/appserver/admingui/web/src/main/resources/configuration/webAvailabilityService.jsf
@@ -84,7 +84,7 @@
 #include "/common/shared/configNameSection.inc"
             <sun:propertySheetSection id="propertSectionTextField">
                 <sun:property id="AvailabilityEnabledProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.availability.availabilityService}" helpText="$resource{i18n_web.availability.webContainerAvailabilityInfoHelp}">
-                    <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
+                    <sun:checkbox  selected="#{pageSession.valueMap['availabilityEnabled']}" selectedValue="true" />
                 </sun:property>
                 <sun:property id="PersistenceTypeProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.availability.persistenceType}" helpText="$resource{i18n_web.availability.persistenceTypeHelp}">
                     <sun:dropDown id="HttpSessionStore" selected="#{pageSession.valueMap['persistenceType']}" labels="#{pageSession.persistenceType}">
@@ -103,7 +103,7 @@
                     <sun:dropDown id="PersistenceScope" selected="#{pageSession.valueMap['persistenceScope']}" labels={"session", "modified-session", "modified-attribute"} />
                 </sun:property>
                 <sun:property id="SingleSignOnProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.availability.singleSignOn}" helpText="$resource{i18n_web.availability.singleSignOnHelp}">
-                    <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['ssoFailoverEnabled']}" selectedValue="true" />
+                    <sun:checkbox  selected="#{pageSession.valueMap['ssoFailoverEnabled']}" selectedValue="true" />
                 </sun:property>
                 "<br /><br />
             </sun:propertySheetSection>

--- a/appserver/admingui/web/src/main/resources/grizzly/networkListenerAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/networkListenerAttr.inc
@@ -118,15 +118,15 @@
         </sun:property>
 
         <sun:property id="status"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.common.status}"  helpText="$resource{i18n_web.grizzly.networkListener.statusHelp}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="security"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.security}" helpText="$resource{i18n_web.grizzly.networkListener.securityHelp}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="JkEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.JkEnabled}" helpText="$resource{i18n_web.grizzly.networkListener.JkEnabledHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['jkenabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['jkenabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="threadpool"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.threadPool}" helpText="$resource{i18n_web.grizzly.networkListener.threadPoolHelp}">

--- a/appserver/admingui/web/src/main/resources/grizzly/networkListenerEdit.jsf
+++ b/appserver/admingui/web/src/main/resources/grizzly/networkListenerEdit.jsf
@@ -153,19 +153,19 @@
     </sun:property>
 
         <sun:property id="status"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.common.status}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['enabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="securityWithHelp"  rendered="#{readOnly}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.security}" helpText="$resource{i18n_web.common.secureAdminHelp}"  >
-            <sun:checkbox disabled="#{readOnly}" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox disabled="#{readOnly}"  selected="#{pageSession.valueMap2['securityEnabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="security"  rendered="#{!readOnly}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.security}"  >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap2['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap2['securityEnabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="JkEnabled"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.JkEnabled}" helpText="$resource{i18n_web.grizzly.networkListener.JkEnabledHelp}">
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['jkEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['jkEnabled']}" selectedValue="true" />
         </sun:property>
 
 

--- a/appserver/admingui/web/src/main/resources/grizzly/protocolAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/protocolAttr.inc
@@ -53,6 +53,6 @@
         </sun:property>
 
         <sun:property id="status"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.protocol.securityEnabled}" >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
 </sun:propertySheetSection>

--- a/appserver/admingui/web/src/main/resources/grizzly/protocolEdit.jsf
+++ b/appserver/admingui/web/src/main/resources/grizzly/protocolEdit.jsf
@@ -140,11 +140,11 @@
         </sun:property>
 
         <sun:property id="statusWithHelp"  rendered="#{readOnly}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.protocol.securityEnabled}" helpText="$resource{i18n_web.common.secureAdminHelp}" >
-            <sun:checkbox disabled="#{readOnly}" label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox disabled="#{readOnly}"  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
 
         <sun:property id="status"  rendered="#{!readOnly}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.protocol.securityEnabled}"  >
-            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
+            <sun:checkbox  selected="#{pageSession.valueMap['securityEnabled']}" selectedValue="true" />
         </sun:property>
 </sun:propertySheetSection>
     </sun:propertySheet>

--- a/appserver/admingui/web/src/main/resources/grizzly/transportAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/transportAttr.inc
@@ -106,7 +106,7 @@
     </sun:property>
 
     <sun:property id="EnableSnoop"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.transport.EnableSnoop}"  helpText="$resource{i18n_web.transport.EnableSnoopHelp}" >
-        <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['enableSnoop']}" selectedValue="true" />
+        <sun:checkbox  selected="#{pageSession.valueMap['enableSnoop']}" selectedValue="true" />
     </sun:property>
 
      <sun:property id="TcpNoDelay"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.transport.TcpNoDelay}" helpText="$resource{i18n_web.transport.TcpNoDelayHelp}">


### PR DESCRIPTION
All the redundant labels have been removed from admingui code as it was causing multiple label error.
Test : Ran the admingui devtests successfully.