### PR TITLE
Updating to latest version of woodstock

### DIFF
--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -61,6 +61,6 @@
 	<parameter-encoding default-charset="UTF-8" />
  </locale-charset-info>
 
-<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.11.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.11.jar:WEB-INF/extra/commons-fileupload-1.3.3.jar:WEB-INF/extra/commons-io-2.5.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
+<class-loader delegate="true" extra-class-path="WEB-INF/extra/webui-jsf-suntheme-4.0.2.12.jar:WEB-INF/extra/dojo-ajax-nodemo-0.4.1.jar:WEB-INF/extra/webui-jsf-4.0.2.12.jar:WEB-INF/extra/commons-fileupload-1.3.3.jar:WEB-INF/extra/commons-io-2.5.jar:WEB-INF/extra/json-1.0.jar:WEB-INF/extra/prototype-1.5.0.jar" />
 
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -67,7 +67,7 @@
         <jstl-api.version>1.2.1</jstl-api.version>
         <mojarra.version>2.3.2</mojarra.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>4.0.2.11</woodstock.version>
+        <woodstock.version>4.0.2.12</woodstock.version>
         <javax.ejb-api.version>3.2</javax.ejb-api.version>
         <javax.interceptor-api.version>1.2.1</javax.interceptor-api.version>
         <javax.xml.rpc-api.version>1.1.1</javax.xml.rpc-api.version>


### PR DESCRIPTION
Updating the glassfish code to be compatible with 4.0.2.12 version of woodstock.
Tests : Successfully ran the gui devtests locally.