### PR TITLE
Removing pkg-java dependency

### DIFF
--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -219,12 +219,6 @@
             <artifactId>jersey-media-json-jackson</artifactId>
             <scope>provided</scope>
         </dependency> 
-        <dependency> <!-- for FindBugs -->
-            <groupId>com.sun.pkg</groupId>
-            <artifactId>pkg-java</artifactId>
-            <version>1.0.0-alpha-1</version>
-            <scope>provided</scope>
-        </dependency> 
 
 
     </dependencies>

--- a/appserver/distributions/minnow/minnow-distributions.xml
+++ b/appserver/distributions/minnow/minnow-distributions.xml
@@ -64,7 +64,6 @@
         <install.package name="glassfish-web"/>
 	<install.package name="glassfish-jdbc"/>
 	<install.package name="glassfish-jmx"/>
-        <install.package name="pkg-java"/>
     </target>
 
     <target name="install-l10n-packages">


### PR DESCRIPTION
The pkg-java dependency is not getting used by admingui module. Hence, need to be removed.
Tested manually. Admin console works fine.