### PR TITLE
Change to new coordinates of codemodel

### DIFF
--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010-2018 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -96,9 +96,9 @@
             <version>3.0-alpha-2</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.codemodel</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>codemodel</artifactId>
-            <version>2.6</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>


### PR DESCRIPTION
GlassFish is using an old version of codemodel and need to be updated to use the new coordinates. Codemodel is now part of JAXB RI