### PR TITLE
Update nucleus security test 

### DIFF
--- a/nucleus/security/services/pom.xml
+++ b/nucleus/security/services/pom.xml
@@ -65,6 +65,7 @@
                 </configuration>
             </plugin>
           </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/nucleus/security/services/pom.xml
+++ b/nucleus/security/services/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2012-2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012-2018 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -52,6 +52,19 @@
     <packaging>glassfish-jar</packaging>
     
     <name>Security Services and SPI</name>
+
+    <build>
+        <plugins>
+            <!-- JDK 8u171+, PasswordAliasTest fails due to serialization issue
+                 Using forked process helps the tests to pass -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkMode>always</forkMode>
+                </configuration>
+            </plugin>
+          </plugins>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
GlassFish build with JDK 8 u171/172 causes following tests to fail:

[INFO] Running org.glassfish.security.services.impl.PasswordAliasTest
Created temporary store /tmp/pwAliasStore3195664634216831007jks
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 1.348 s <<< FAILURE! - in org.glassfish.security.services.impl.PasswordAliasTest
[ERROR] checkLongPW(org.glassfish.security.services.impl.PasswordAliasTest)  Time elapsed: 0.61 s  <<< ERROR!
java.lang.RuntimeException: java.io.IOException: Invalid secret key format
        at org.glassfish.security.services.impl.PasswordAliasTest.checkStoreAndGetPWByAlias(PasswordAliasTest.java:98)
        at org.glassfish.security.services.impl.PasswordAliasTest.checkLongPW(PasswordAliasTest.java:94)
Caused by: java.io.IOException: Invalid secret key format
        at org.glassfish.security.services.impl.PasswordAliasTest.checkStoreAndGetPWByAlias(PasswordAliasTest.java:98)
        at org.glassfish.security.services.impl.PasswordAliasTest.checkLongPW(PasswordAliasTest.java:94)

[ERROR] checkShortPW(org.glassfish.security.services.impl.PasswordAliasTest)  Time elapsed: 0.626 s  <<< ERROR!
java.lang.RuntimeException: java.io.IOException: Invalid secret key format
        at org.glassfish.security.services.impl.PasswordAliasTest.checkStoreAndGetPWByAlias(PasswordAliasTest.java:98)
        at org.glassfish.security.services.impl.PasswordAliasTest.checkShortPW(PasswordAliasTest.java:89)
Caused by: java.io.IOException: Invalid secret key format
        at org.glassfish.security.services.impl.PasswordAliasTest.checkStoreAndGetPWByAlias(PasswordAliasTest.java:98)
        at org.glassfish.security.services.impl.PasswordAliasTest.checkShortPW(PasswordAliasTest.java:89)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   PasswordAliasTest.checkLongPW:94->checkStoreAndGetPWByAlias:98 » Runtime java....
[ERROR]   PasswordAliasTest.checkShortPW:89->checkStoreAndGetPWByAlias:98 » Runtime java...

Credit goes to @tjquinno for proposing this change. The fix is to make maven surefire plug-in run to run test in a forked process. Not doing so seems to not include JRE's extension directory causing serialization issue.
