### PR TITLE
Fixing some dependencies and cleaning up POMs

### DIFF
--- a/appserver/admingui/war/src/main/webapp/META-INF/MANIFEST.MF
+++ b/appserver/admingui/war/src/main/webapp/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Build-Jdk: 1.5.0_13
 Glassfish-require-repository: console-plugins=${com.sun.aas.installRoo
  t}/lib/console-plugins
 Glassfish-require-services: org.glassfish.api.admingui.ConsoleProvider
-HK2-Import-Bundles: org.glassfish.admingui.console-common,com.sun.enterprise.hk2,org.glassfish.admingui.console-plugin-service, org.glassfish.deployment.deployment-client,org.glassfish.registration.registration-api,org.glassfish.registration.registration-impl, org.glassfish.javax.servlet, javax.servlet.jsp, org.glassfish.jsftemplating, org.glassfish.admingui.dataprovider, com.sun.pkg.client
+HK2-Import-Bundles: org.glassfish.admingui.console-common,com.sun.enterprise.hk2,org.glassfish.admingui.console-plugin-service, org.glassfish.deployment.deployment-client, org.glassfish.javax.servlet, javax.servlet.jsp, org.glassfish.jsftemplating, org.glassfish.admingui.dataprovider
 s

--- a/appserver/core/api-exporter-fragment/pom.xml
+++ b/appserver/core/api-exporter-fragment/pom.xml
@@ -338,9 +338,7 @@ org.glassfish.hk2.security.ssl; \
 com.sun.org.apache.xerces.internal.jaxp; \
 com.sun.org.apache.xalan.internal.xsltc.trax; \
 com.sun.org.apache.xerces.internal.parsers; \
-com.sun.pkg.client; \
 com.ctc.wstx.stax; \
-com.sun.jmx.remote.protocol.jmxmp; \
 org.glassfish.hk2.security.provider; \
 org.glassfish.hk2.security.auth.realm.file; \
 org.glassfish.hk2.security.auth.realm.certificate; \

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -104,7 +104,6 @@
         <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
         <webservices.version>2.4.1</webservices.version>
         <woodstox.version>4.4.1</woodstox.version>
-        <jaxb-api.version>2.3.0</jaxb-api.version>
         <jaxb.version>2.3.0.1</jaxb.version>
         <stax2-api.version>3.1.4</stax2-api.version>
         <javax.xml.registry-api.version>1.0.8</javax.xml.registry-api.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -943,13 +943,12 @@
             <!--
                 only used to satisfy findbugs,
                 can be removed once GLASSFISH-20835 is resolved
-
+            -->
             <dependency>
                 <groupId>org.netbeans.external</groupId>
                 <artifactId>ddl</artifactId>
                 <version>RELEASE82</version>
             </dependency>
-                        -->
             <dependency>
                 <groupId>org.glassfish.tyrus</groupId>
                 <artifactId>tyrus-bom</artifactId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -101,7 +101,6 @@
         <javaee.version>${javaee.major_version}.${minor_version}${javaee.version_qualifier}</javaee.version>
 
         <jsftemplating.version>2.1.3</jsftemplating.version>
-        <uc-pkg-bootstrap.version>1.122-57.2889</uc-pkg-bootstrap.version>
         <webservices.version>2.4.1</webservices.version>
         <woodstox.version>4.4.1</woodstox.version>
         <jaxb.version>2.3.0.1</jaxb.version>
@@ -128,7 +127,7 @@
         <com.ibm.jbatch.container.version>1.0.2</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>1.0.2</com.ibm.jbatch.spi.version>
         <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
-	<jboss.classfilewriter.version>1.2.1.Final</jboss.classfilewriter.version>
+	    <jboss.classfilewriter.version>1.2.1.Final</jboss.classfilewriter.version>
         <easymock.version>3.5</easymock.version>
     </properties>
 
@@ -136,8 +135,8 @@
 	
         <module>common</module>
         <module>libpam4j</module>
-	<module>jaxr-ra</module>
-	<module>ldapbp</module> 
+	    <module>jaxr-ra</module>
+	    <module>ldapbp</module>
         <module>ha</module>
         <module>deployment</module>
         <module>admin</module>
@@ -563,11 +562,11 @@
                 <artifactId>javax.inject</artifactId>
                 <version>${javax.inject.version}</version>
             </dependency>
-	    <dependency>
-		<groupId>javax.resource</groupId>
-		<artifactId>javax.resource-api</artifactId>
-		<version>${javax.resource-api.version}</version>
-	    </dependency>
+            <dependency>
+                <groupId>javax.resource</groupId>
+                <artifactId>javax.resource-api</artifactId>
+                <version>${javax.resource-api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>javax.enterprise.deploy</groupId>
                 <artifactId>javax.enterprise.deploy-api</artifactId>
@@ -668,20 +667,15 @@
                 <artifactId>jaxb-api</artifactId>
                 <version>${jaxb-api.version}</version>
             </dependency>
-	    <dependency>
+	        <dependency>
             	<groupId>javax.xml.registry</groupId>
-	        <artifactId>javax.xml.registry-api</artifactId>
-		<version>${javax.xml.registry-api.version}</version>
+	            <artifactId>javax.xml.registry-api</artifactId>
+                <version>${javax.xml.registry-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
                 <version>${stax2-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.jbi</groupId>
-                <artifactId>jbi</artifactId>
-                <version>${jbi.version}</version>
             </dependency>
             <dependency>
                 <groupId>wsdl4j</groupId>
@@ -714,11 +708,7 @@
                 <artifactId>weld-se-shaded</artifactId>
                 <version>${weld.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.sun.pkg</groupId>
-                <artifactId>pkg-bootstrap</artifactId>
-                <version>${uc-pkg-bootstrap.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>javax.servlet.jsp</artifactId>
@@ -846,11 +836,6 @@
                 <version>${javax.management.j2ee-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>genericra</artifactId>
-                <version>2.0-20081121</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>osgi-resource-locator</artifactId>
                 <version>1.0.1</version>
@@ -958,12 +943,13 @@
             <!--
                 only used to satisfy findbugs,
                 can be removed once GLASSFISH-20835 is resolved
-            -->
+
             <dependency>
                 <groupId>org.netbeans.external</groupId>
                 <artifactId>ddl</artifactId>
                 <version>RELEASE82</version>
             </dependency>
+                        -->
             <dependency>
                 <groupId>org.glassfish.tyrus</groupId>
                 <artifactId>tyrus-bom</artifactId>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -132,28 +132,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <aggregate>true</aggregate>
-                                <minmemory>128m</minmemory>
-                                <maxmemory>512m</maxmemory>
-                                <source>1.5</source>
-                                <verbose>false</verbose>
-                                <linksource>true</linksource>
-                                <links>
-                                    <link>http://java.sun.com/javase/6/docs/api/</link>
-                                </links>
-                                <show>private</show>
-                            </configuration>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <minmemory>128m</minmemory>
+                    <maxmemory>512m</maxmemory>
+                    <verbose>false</verbose>
+                    <linksource>true</linksource>
+                    <links>
+                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                    </links>
+                    <show>private</show>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <dependencies>
         <dependency>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -138,11 +138,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.stream</groupId>
-            <artifactId>sjsxp</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
             <scope>test</scope>

--- a/nucleus/admin/monitor/pom.xml
+++ b/nucleus/admin/monitor/pom.xml
@@ -77,21 +77,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-report-plugin</artifactId>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
             </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/admin/server-mgmt/pom.xml
+++ b/nucleus/admin/server-mgmt/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.1</version>
+            <version>${jaxb-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/nucleus/core/kernel/osgi.bundle
+++ b/nucleus/core/kernel/osgi.bundle
@@ -51,8 +51,6 @@
 
 # dependent flashlight package resolved at runtime
 DynamicImport-Package: org.glassfish.flashlight.provider, \
-                       com.sun.pkg.client, \
-		       org.glassfish.branding, \
                        org.objectweb.asm;password=GlassFish, \
                        org.objectweb.asm.commons;password=GlassFish
 

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -150,7 +150,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal-api-only</artifactId>
+            <artifactId>gmbal</artifactId>
             <version>${gmbal.grizzly.version}</version>
             <scope>provided</scope>
         </dependency>        

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.3</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.5.3</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0.4</version>
+            <version>3.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>3.0-alpha-2</version>
+            <artifactId>maven-core</artifactId>
+            <version>3.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -132,7 +132,7 @@
             <version>${hk2.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator.version}</version>
         </dependency>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -137,7 +137,6 @@
         <javassist.version>3.22.0-GA</javassist.version>
         <javax.el.version>3.0.1-b10</javax.el.version>
         <javax.el-api.version>3.0.1-b06</javax.el-api.version>
-        <saaj-api.version>1.4.0</saaj-api.version>
         <hk2.version>2.5.0-b60</hk2.version>
         <hk2.plugin.version>2.5.0-b57</hk2.plugin.version>
         <jboss.logging.version>3.3.1.Final</jboss.logging.version>
@@ -154,14 +153,11 @@
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1</jax-rs-api.impl.version>
         <mimepull.version>1.9.7</mimepull.version>
-        <jbi.version>1.0</jbi.version>
         <glassfish-management-api.version>3.2.1-b003</glassfish-management-api.version>
-        <opendmk.version>1.0-b01-ea</opendmk.version>
         <asm.version>6.0_ALPHA</asm.version>
         <shoal.version>1.6.52</shoal.version>
         <ha-api.version>3.1.11</ha-api.version>
         <glassfishbuild.version>3.2.24</glassfishbuild.version>
-        <source-annotation-processor.version>1.0</source-annotation-processor.version>
         <logging-annotation-processor.version>1.8</logging-annotation-processor.version>
         <command-security-plugin.version>1.0.9</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
@@ -383,7 +379,7 @@
                             <pattern>/readme</pattern>
                             <pattern>cluster/cli/src/test/resources/fake_gf_install_dir/junk</pattern>
                         </exclude>
-			<ignoreYear>true</ignoreYear> 
+			            <ignoreYear>true</ignoreYear>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -719,11 +715,6 @@
                 <version>${antlr.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.jbi</groupId>
-                <artifactId>jbi</artifactId>
-                <version>${jbi.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.external</groupId>
                 <artifactId>management-api</artifactId>
                 <version>${glassfish-management-api.version}</version>
@@ -918,11 +909,6 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${servlet-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>asm</groupId>
-                <artifactId>asm-commons</artifactId>
-                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -150,6 +150,7 @@
         <jersey.version>2.26</jersey.version>
         <jackson.version>2.9.4</jackson.version>
         <jettison.version>1.3.7</jettison.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1</jax-rs-api.impl.version>
         <mimepull.version>1.9.7</mimepull.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -711,11 +711,6 @@
                 <version>1.0.1</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.stream</groupId>
-                <artifactId>sjsxp</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>${jax-rs-api.impl.version}</version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -612,31 +612,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>findbugs-maven-plugin</artifactId>
-                            <version>${findbugs.version}</version>
-                            <configuration>
-                                <skip>${findbugs.skip}</skip>
-                                <threshold>${findbugs.threshold}</threshold>
-                                <excludeFilterFile>
-                                    exclude-common.xml,${findbugs.exclude}
-                                </excludeFilterFile>
-                            </configuration>
-                            <!--
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.glassfish.main</groupId>
-                                    <artifactId>findbugs</artifactId>
-                                    <version>${project.version}</version>
-                                </dependency>
-                            </dependencies>
-                            -->
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>
@@ -657,6 +632,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs.version}</version>
+                <configuration>
+                    <skip>${findbugs.skip}</skip>
+                    <threshold>${findbugs.threshold}</threshold>
+                    <excludeFilterFile>
+                        exclude-common.xml,${findbugs.exclude}
+                    </excludeFilterFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <dependencyManagement>
         <dependencies>

--- a/nucleus/test-utils/utils/pom.xml
+++ b/nucleus/test-utils/utils/pom.xml
@@ -72,10 +72,6 @@
             <artifactId>hk2-core</artifactId>
         </dependency> 
         <dependency>
-            <groupId>com.sun.xml.stream</groupId>
-            <artifactId>sjsxp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
-Removed sjsxp dependency since its part of JavaSE
-Removed gmbal-api-only dependency (after discussing with Russ)
-Fixed jaxb-api since we were depending on 2 different versions
-Fixed issue #22532 
-Updated maven-core and maven-plugin API to 3.3.9 (I would like to update to maven 3.5.3 but that requires changes in our infra)
-Removed many unwanted/unused properties in main POMs
