### PR TITLE
Update maven central URLs to use https

### DIFF
--- a/appserver/admingui/devtests/hudson.xml
+++ b/appserver/admingui/devtests/hudson.xml
@@ -82,7 +82,7 @@
     <property name="ant.contrib.url"
               value="http://mirrors.ibiblio.org/pub/mirrors/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"/>
     <property name="maven.ant.tasks.url"
-              value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
+              value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
     <property name="glassfish.dist.url"
               value="http://hudson.glassfish.org/job/gf-trunk-build-continuous/lastSuccessfulBuild/artifact/bundles/glassfish.zip"/>
 

--- a/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
+++ b/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
@@ -55,7 +55,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
@@ -103,7 +103,7 @@
 
         
 <target name="init" depends="init.os,init.tools,setAsadminArgs">
-    <get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
+    <get src="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
     <property name="root" value="${basedir}"/>
 
     <available property="cluster.exists" file="${s1as.home}/domains/${testDomain}"/>

--- a/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
@@ -55,7 +55,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
@@ -58,7 +58,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
@@ -55,7 +55,7 @@
    &commonRun;
    &testProperties;  
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
@@ -58,7 +58,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"


### PR DESCRIPTION
This is similar to the commit https://github.com/eclipse-ee4j/glassfish/commit/cf03307e27926544189f490d4fd1d0ee23c8059d in eclipse glassfish repo to update the maven urls to working ones.

Signed-off-by: Alwin Joseph <alwin.joseph@oracle.com>